### PR TITLE
Add emergency config management

### DIFF
--- a/app.py
+++ b/app.py
@@ -664,6 +664,10 @@ def unified_links(local_username, app_key):
             all_links, errors, remote_info = collect_links(mappings, local_username, want_html)
 
     uniq = filter_dedupe(all_links)
+    emerg = get_setting(owner_id, "emergency_config")
+    if emerg:
+        uniq.append(emerg.strip())
+        uniq = filter_dedupe(uniq)
     if uniq:
         body = "\n".join(uniq) + "\n"
     elif errors:


### PR DESCRIPTION
## Summary
- Allow admins to configure an emergency config link via new admin panel button
- Store emergency config in settings table and append to subscription output

## Testing
- `python -m py_compile bot.py app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68c3055736448328b285d617df84ed10