### PR TITLE
Fix indentation in docker-compose app service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,27 +26,27 @@ services:
     depends_on:
       mysql:
         condition: service_healthy
-      environment:
-        MYSQL_HOST: ${MYSQL_HOST}
-        MYSQL_PORT: ${MYSQL_PORT}
-        MYSQL_USER: ${MYSQL_USER}
-        MYSQL_PASSWORD: ${MYSQL_PASSWORD}
-        MYSQL_DATABASE: ${MYSQL_DATABASE}
-        PUBLIC_BASE_URL: ${PUBLIC_BASE_URL}
-        FLASK_HOST: ${FLASK_HOST}
-        FLASK_PORT: ${FLASK_PORT}
-        SSL_CERT_PATH: ${SSL_CERT_PATH}
-        SSL_KEY_PATH: ${SSL_KEY_PATH}
-        WORKERS: ${WORKERS}
-        # Set ASYNC_WORKERS to enable gevent worker class for higher concurrency
-        ASYNC_WORKERS: ${ASYNC_WORKERS}
-        JWT_SECRET: ${JWT_SECRET}
-        SERVICE: app
+    environment:
+      MYSQL_HOST: ${MYSQL_HOST}
+      MYSQL_PORT: ${MYSQL_PORT}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      PUBLIC_BASE_URL: ${PUBLIC_BASE_URL}
+      FLASK_HOST: ${FLASK_HOST}
+      FLASK_PORT: ${FLASK_PORT}
+      SSL_CERT_PATH: ${SSL_CERT_PATH}
+      SSL_KEY_PATH: ${SSL_KEY_PATH}
+      WORKERS: ${WORKERS}
+      # Set ASYNC_WORKERS to enable gevent worker class for higher concurrency
+      ASYNC_WORKERS: ${ASYNC_WORKERS}
+      JWT_SECRET: ${JWT_SECRET}
+      SERVICE: app
     ports:
       - "${FLASK_PORT:-5000}:${FLASK_PORT:-5000}"
-      volumes:
-        - ./certs:/app/certs:ro
-        - ./frontend:/app/frontend:ro
+    volumes:
+      - ./certs:/app/certs:ro
+      - ./frontend:/app/frontend:ro
 
   bot:
     build: .


### PR DESCRIPTION
## Summary
- fix indentation of `app` service environment and volumes in Docker Compose

## Testing
- `docker compose config` *(fails: command not found)*
- `pip install pyyaml` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68c55201678c83288f4464097c44d9e0