### PR TITLE
Fix initialization order for portal users table

### DIFF
--- a/app.py
+++ b/app.py
@@ -92,8 +92,6 @@ def init_portal_users_table():
             """
         )
 
-init_portal_users_table()
-
 FETCH_CACHE_TTL = int(os.getenv("FETCH_CACHE_TTL", "300"))
 _fetch_user_cache = TTLCache(maxsize=256, ttl=FETCH_CACHE_TTL)
 _fetch_user_lock = RLock()
@@ -118,6 +116,8 @@ class CurCtx:
         finally:
             self.cur.close()
             self.conn.close()
+
+init_portal_users_table()
 
 def admin_ids():
     ids = (os.getenv("ADMIN_IDS") or "").strip()


### PR DESCRIPTION
## Summary
- Move `init_portal_users_table()` invocation after the `CurCtx` context manager is defined so it no longer raises a `NameError` at startup.

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68c5550d2acc8328968bcb5419e471f9