### PR TITLE
Add API token generation and rotation for agents

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,11 +1,22 @@
-from fastapi import FastAPI, APIRouter
+import os
+
+from fastapi import FastAPI, APIRouter, HTTPException, Header, Depends
 from dotenv import load_dotenv
 
-from bot import init_mysql_pool
+from bot import init_mysql_pool, ensure_schema
+from models.agents import rotate_api_token
 
 app = FastAPI()
 
 router = APIRouter()
+
+
+ADMIN_API_TOKEN = os.getenv("ADMIN_API_TOKEN", "")
+
+
+async def require_admin(x_admin_token: str = Header(...)):
+    if not ADMIN_API_TOKEN or x_admin_token != ADMIN_API_TOKEN:
+        raise HTTPException(status_code=403, detail="Forbidden")
 
 
 @router.get("/health")
@@ -14,11 +25,21 @@ async def health_check():
     return {"status": "ok"}
 
 
+@router.post("/agents/{agent_id}/token")
+async def rotate_agent_token_endpoint(agent_id: int, _: None = Depends(require_admin)):
+    try:
+        token = rotate_api_token(agent_id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    return {"api_token": token}
+
+
 @app.on_event("startup")
 async def startup_event():
     """Initialize resources on application startup."""
     load_dotenv()
     init_mysql_pool()
+    ensure_schema()
 
 
 app.include_router(router, prefix="/api/v1")

--- a/models/agents.py
+++ b/models/agents.py
@@ -1,0 +1,25 @@
+import hashlib
+import secrets
+
+from bot import with_mysql_cursor
+
+
+def generate_api_token() -> tuple[str, str]:
+    """Generate a random API token and its hash."""
+    token = secrets.token_hex(32)
+    token_hash = hashlib.sha256(token.encode()).hexdigest()
+    return token, token_hash
+
+
+def rotate_api_token(agent_id: int) -> str:
+    """Generate and store a new API token for the agent.
+
+    Returns the raw token so it can be shown once to the caller.
+    Raises ValueError if the agent does not exist.
+    """
+    token, token_hash = generate_api_token()
+    with with_mysql_cursor() as cur:
+        cur.execute("UPDATE agents SET api_token=%s WHERE id=%s", (token_hash, agent_id))
+        if cur.rowcount == 0:
+            raise ValueError("agent not found")
+    return token


### PR DESCRIPTION
## Summary
- add `api_token` column and migration for agents table
- generate and hash API tokens when creating or rotating agents
- expose admin endpoint to rotate agent tokens

## Testing
- `pytest`
- `python -m py_compile bot.py api/main.py models/agents.py`


------
https://chatgpt.com/codex/tasks/task_b_68c56248b7c0832895d7a2315ed11ad7