### PR TITLE
Add FastAPI service branch to start script

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -3,7 +3,9 @@ set -e
 
 /app/wait-for-mysql.sh
 
-if [ "${SERVICE:-app}" = "app" ]; then
+service="${SERVICE:-app}"
+
+if [ "$service" = "app" ]; then
   timeout=${GUNICORN_TIMEOUT:-120}
   cert_args=()
   worker_class=()
@@ -22,6 +24,8 @@ if [ "${SERVICE:-app}" = "app" ]; then
   exec gunicorn --workers "$workers" "${worker_class[@]}" --timeout "$timeout" \
     --bind "${FLASK_HOST:-0.0.0.0}:${FLASK_PORT:-5000}" \
     "${cert_args[@]}" app:app
+elif [ "$service" = "api" ]; then
+  exec uvicorn api.main:app --host "${FASTAPI_HOST:-0.0.0.0}" --port "${FASTAPI_PORT:-5000}"
 else
-  exec python -m "${SERVICE}"
+  exec python -m "$service"
 fi


### PR DESCRIPTION
## Summary
- support running FastAPI via uvicorn when `SERVICE=api`
- retain existing Gunicorn setup for `SERVICE=app`

## Testing
- `bash -n start.sh`
- `shellcheck start.sh` *(fails: command not found; `apt-get update` 403, unable to install)*

------
https://chatgpt.com/codex/tasks/task_b_68c56ec6d2488328a1d8e77c236050cd