### PR TITLE
Add FastAPI docs service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,29 @@ services:
     volumes:
       - ./certs:/app/certs:ro
 
+  fastapi-docs:
+    build: .
+    image: ${IMAGE:-ghcr.io/rh8888/valhallabot:v1.0.0}
+    container_name: valhalla-fastapi-docs
+    restart: unless-stopped
+    depends_on:
+      mysql:
+        condition: service_healthy
+    environment:
+      MYSQL_HOST: ${MYSQL_HOST}
+      MYSQL_PORT: ${MYSQL_PORT}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      PUBLIC_BASE_URL: ${PUBLIC_BASE_URL}
+      FASTAPI_HOST: ${FASTAPI_HOST}
+      FASTAPI_PORT: ${FASTAPI_PORT}
+      SERVICE: api
+    ports:
+      - "5000:5000"
+    volumes:
+      - ./certs:/app/certs:ro
+
   bot:
     build: .
     image: ${IMAGE:-ghcr.io/rh8888/valhallabot:v1.0.0}


### PR DESCRIPTION
## Summary
- add fastapi-docs service for serving documentation via FastAPI

## Testing
- `python -m pytest`
- `python - <<'PY'
import yaml, sys
with open('docker-compose.yml') as f:
    yaml.safe_load(f)
print('docker-compose.yml loaded successfully')
PY`


------
https://chatgpt.com/codex/tasks/task_b_68c5715697c48328b1dea12f4c5c89ef