### PR TITLE
Update API router prefix

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -39,6 +39,6 @@ async def startup_event():
     ensure_schema()
 
 
-app.include_router(router, prefix="/api/v1")
+app.include_router(router, prefix="/v1")
 
 __all__ = ("app",)


### PR DESCRIPTION
## Summary
- simplify API prefix by removing `/api`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68c5753b124c8328a2f8118a26a924e9