### PR TITLE
Mount FastAPI under /api via Dispatcher

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,7 +25,10 @@ from datetime import datetime
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dotenv import load_dotenv
 from mysql.connector import pooling
+from asgiref.wsgi import AsgiToWsgi
+from werkzeug.middleware.dispatcher import DispatcherMiddleware
 from apis import sanaei
+from api.main import app as api_app
 
 logging.basicConfig(
     format="%(asctime)s | %(levelname)s | flask_agg | %(message)s",
@@ -504,6 +507,11 @@ def bytesformat(num):
 
 
 app.jinja_env.filters["bytesformat"] = bytesformat
+
+# Mount the FastAPI application under /api
+app.wsgi_app = DispatcherMiddleware(
+    app.wsgi_app, {"/api": AsgiToWsgi(api_app)}
+)
 
 
 def build_user(local_username, app_key, lu, remote=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ gunicorn==22.0.0
 gevent==24.2.1
 fastapi==0.111.0
 uvicorn==0.30.1
+asgiref==3.8.1


### PR DESCRIPTION
## Summary
- wrap the FastAPI app with AsgiToWsgi and mount under `/api` using DispatcherMiddleware
- add asgiref dependency

## Testing
- `python -m py_compile app.py`
- `pytest`
- `pip install asgiref==3.8.1` *(fails: Could not find a version that satisfies the requirement asgiref==3.8.1)*

------
https://chatgpt.com/codex/tasks/task_b_68c57b3d6ffc8328972e401f9d2aa514