### PR TITLE
Simplify startup script to run app via gunicorn

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -3,29 +3,21 @@ set -e
 
 /app/wait-for-mysql.sh
 
-service="${SERVICE:-app}"
+timeout=${GUNICORN_TIMEOUT:-120}
+cert_args=()
+worker_class=()
 
-if [ "$service" = "app" ]; then
-  timeout=${GUNICORN_TIMEOUT:-120}
-  cert_args=()
-  worker_class=()
-
-  if [ -n "$ASYNC_WORKERS" ]; then
-    workers="$ASYNC_WORKERS"
-    worker_class=(--worker-class gevent)
-  else
-    workers=${WORKERS:-$((2 * $(nproc) + 1))}
-  fi
-
-  if [ -n "$SSL_CERT_PATH" ] && [ -n "$SSL_KEY_PATH" ]; then
-    cert_args=(--certfile "$SSL_CERT_PATH" --keyfile "$SSL_KEY_PATH")
-  fi
-
-  exec gunicorn --workers "$workers" "${worker_class[@]}" --timeout "$timeout" \
-    --bind "${FLASK_HOST:-0.0.0.0}:${FLASK_PORT:-5000}" \
-    "${cert_args[@]}" app:app
-elif [ "$service" = "api" ]; then
-  exec uvicorn api.main:app --host "${FASTAPI_HOST:-0.0.0.0}" --port "${FASTAPI_PORT:-5000}"
+if [ -n "$ASYNC_WORKERS" ]; then
+  workers="$ASYNC_WORKERS"
+  worker_class=(--worker-class gevent)
 else
-  exec python -m "$service"
+  workers=${WORKERS:-$((2 * $(nproc) + 1))}
 fi
+
+if [ -n "$SSL_CERT_PATH" ] && [ -n "$SSL_KEY_PATH" ]; then
+  cert_args=(--certfile "$SSL_CERT_PATH" --keyfile "$SSL_KEY_PATH")
+fi
+
+exec gunicorn --workers "$workers" "${worker_class[@]}" --timeout "$timeout" \
+  --bind "${FLASK_HOST:-0.0.0.0}:${FLASK_PORT:-5000}" \
+  "${cert_args[@]}" app:app


### PR DESCRIPTION
## Summary
- Drop service branching in `start.sh`
- Always start gunicorn with `app:app` bound to `FLASK_PORT`

## Testing
- `pytest` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_b_68c57c03a4588328a7a031ee75a43ae0