### PR TITLE
Remove fastapi-docs service and expose app on port 443

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,30 +42,7 @@ services:
       ASYNC_WORKERS: ${ASYNC_WORKERS}
       SERVICE: app
     ports:
-      - "${FLASK_PORT:-5000}:${FLASK_PORT:-5000}"
-    volumes:
-      - ./certs:/app/certs:ro
-
-  fastapi-docs:
-    build: .
-    image: ${IMAGE:-ghcr.io/rh8888/valhallabot:v1.0.0}
-    container_name: valhalla-fastapi-docs
-    restart: unless-stopped
-    depends_on:
-      mysql:
-        condition: service_healthy
-    environment:
-      MYSQL_HOST: ${MYSQL_HOST}
-      MYSQL_PORT: ${MYSQL_PORT}
-      MYSQL_USER: ${MYSQL_USER}
-      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
-      MYSQL_DATABASE: ${MYSQL_DATABASE}
-      PUBLIC_BASE_URL: ${PUBLIC_BASE_URL}
-      FASTAPI_HOST: ${FASTAPI_HOST}
-      FASTAPI_PORT: ${FASTAPI_PORT}
-      SERVICE: api
-    ports:
-      - "5000:5000"
+      - "443:${FLASK_PORT:-5000}"
     volumes:
       - ./certs:/app/certs:ro
 


### PR DESCRIPTION
## Summary
- remove the fastapi-docs service from docker-compose
- map the app service to publish port 443

## Testing
- `docker compose config` *(fails: command not found)*
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_b_68c57cb6e32083288bafec45ab4615ab