### PR TITLE
Expose agent token management endpoints

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -276,6 +276,7 @@ def ensure_schema():
                 max_user_bytes BIGINT NOT NULL DEFAULT 0,
                 total_used_bytes BIGINT NOT NULL DEFAULT 0,
                 api_token CHAR(64) UNIQUE,
+                api_token_raw TEXT,
                 disabled_pushed TINYINT(1) NOT NULL DEFAULT 0,
                 disabled_pushed_at DATETIME NULL,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
@@ -297,6 +298,10 @@ def ensure_schema():
             pass
         try:
             cur.execute("ALTER TABLE agents ADD COLUMN api_token CHAR(64) UNIQUE")
+        except MySQLError:
+            pass
+        try:
+            cur.execute("ALTER TABLE agents ADD COLUMN api_token_raw TEXT")
         except MySQLError:
             pass
         if added_total:
@@ -1018,9 +1023,9 @@ def upsert_agent(tg_id: int, name: str):
             return None
         token, token_hash = generate_api_token()
         cur.execute(
-            "INSERT INTO agents(telegram_user_id,name,plan_limit_bytes,expire_at,active,user_limit,max_user_bytes,api_token) "
-            "VALUES(%s,%s,0,NULL,1,0,0,%s)",
-            (tg_id, name, token_hash),
+            "INSERT INTO agents(telegram_user_id,name,plan_limit_bytes,expire_at,active,user_limit,max_user_bytes,api_token,api_token_raw) "
+            "VALUES(%s,%s,0,NULL,1,0,0,%s,%s)",
+            (tg_id, name, token_hash, token),
         )
         return token
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -25,15 +25,29 @@ endpoints.
 
 ### Agent tokens
 
-Agent API tokens are stored hashed in the database. To issue or rotate an agent
-token, an admin must call:
+Agent API tokens are stored hashed in the database while a copy of the raw
+token is kept so agents can retrieve it later.
+
+Agents may view their current token:
+
+```
+GET /api/v1/agents/me/token
+```
+
+Agents may also rotate their own token:
+
+```
+POST /api/v1/agents/me/token
+```
+
+Administrators can rotate a token for any agent:
 
 ```
 POST /api/v1/agents/{agent_id}/token
 ```
 
-The response includes the new `api_token`. It is only shown once and should be
-stored securely by the caller.
+The response for any rotation includes the new `api_token`. It is only shown
+once and should be stored securely by the caller.
 
 ## Role-based access
 
@@ -58,6 +72,22 @@ curl -X POST \
   -H "Authorization: Bearer $ADMIN_TOKEN" \
   "http://localhost:${FLASK_PORT}/api/v1/agents/123/token"
 ```
+
+### Get current agent token
+
+```sh
+curl -H "Authorization: Bearer $AGENT_TOKEN" \
+  "http://localhost:${FLASK_PORT}/api/v1/agents/me/token"
+```
+
+### Rotate my agent token
+
+```sh
+curl -X POST \
+  -H "Authorization: Bearer $AGENT_TOKEN" \
+  "http://localhost:${FLASK_PORT}/api/v1/agents/me/token"
+```
+
 
 ### List users
 

--- a/models/agents.py
+++ b/models/agents.py
@@ -20,7 +20,25 @@ def rotate_api_token(agent_id: int) -> str:
     from bot import with_mysql_cursor
 
     with with_mysql_cursor() as cur:
-        cur.execute("UPDATE agents SET api_token=%s WHERE id=%s", (token_hash, agent_id))
+        cur.execute(
+            "UPDATE agents SET api_token=%s, api_token_raw=%s WHERE id=%s",
+            (token_hash, token, agent_id),
+        )
         if cur.rowcount == 0:
             raise ValueError("agent not found")
     return token
+
+
+def get_api_token(agent_id: int) -> str:
+    """Retrieve the raw API token for an agent.
+
+    Raises ValueError if the agent does not exist or no token is stored.
+    """
+    from bot import with_mysql_cursor
+
+    with with_mysql_cursor() as cur:
+        cur.execute("SELECT api_token_raw FROM agents WHERE id=%s", (agent_id,))
+        row = cur.fetchone()
+        if not row or row["api_token_raw"] is None:
+            raise ValueError("agent not found")
+    return row["api_token_raw"]


### PR DESCRIPTION
## Summary
- store raw agent API tokens and expose retrieval helper
- add `/agents/me/token` GET and POST endpoints
- document agent token retrieval and rotation

## Testing
- `pytest`
- `python -m py_compile models/agents.py api/main.py bot.py`


------
https://chatgpt.com/codex/tasks/task_b_68c59a022a8c8328a1c7516353c5dec6