### PR TITLE
feat: persist admin token in database

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -181,6 +181,14 @@ def with_mysql_cursor(dict_=True):
 def ensure_schema():
     with with_mysql_cursor() as cur:
         cur.execute("""
+            CREATE TABLE IF NOT EXISTS admins(
+                id BIGINT PRIMARY KEY AUTO_INCREMENT,
+                api_token VARCHAR(128) NOT NULL UNIQUE,
+                is_super TINYINT(1) NOT NULL DEFAULT 0,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+        """)
+        cur.execute("""
             CREATE TABLE IF NOT EXISTS panels(
                 id BIGINT PRIMARY KEY AUTO_INCREMENT,
                 telegram_user_id BIGINT NOT NULL,

--- a/docs/api.md
+++ b/docs/api.md
@@ -19,9 +19,15 @@ Authorization: Bearer <token>
 
 ### Admin tokens
 
-Set the `ADMIN_API_TOKEN` environment variable before starting the application
-and use its value as the bearer token. Admin tokens allow access to privileged
-endpoints.
+Admin API tokens are stored in the database. A super-admin can view the
+current token and generate a new one via the following endpoints:
+
+```
+GET /api/v1/admin/token
+POST /api/v1/admin/token
+```
+
+Use the returned `token` value as the bearer token for privileged requests.
 
 ### Agent tokens
 

--- a/scripts/migrate_admin_token.py
+++ b/scripts/migrate_admin_token.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+import os
+
+from dotenv import load_dotenv
+
+from bot import ensure_schema, with_mysql_cursor
+
+
+def main():
+    load_dotenv()
+    token = os.getenv("ADMIN_API_TOKEN")
+    if not token:
+        print("ADMIN_API_TOKEN not set; nothing to migrate.")
+        return
+
+    ensure_schema()
+    with with_mysql_cursor() as cur:
+        cur.execute("SELECT id FROM admins WHERE is_super=1")
+        row = cur.fetchone()
+        if row:
+            print("Admin token already present; skipping.")
+            return
+        cur.execute("INSERT INTO admins (api_token, is_super) VALUES (%s, 1)", (token,))
+        print("Admin token migrated.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- store admin API token in `admins` table and validate against DB
- expose GET/POST `/admin/token` for super-admin token rotation
- add migration script to move `ADMIN_API_TOKEN` env var into DB

## Testing
- `python -m py_compile api/auth.py api/admin.py bot.py scripts/migrate_admin_token.py`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_b_68c59b2032308328b77cbe60546b35b2