### PR TITLE
feat: add API token management

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -46,6 +46,10 @@ Agents may also rotate their own token:
 POST /api/v1/agents/me/token
 ```
 
+Agents can also view or rotate their token directly from the Telegram bot via
+the **API Token** menu. Administrators may view or rotate any agent's token
+through the bot's agent management panel.
+
 Administrators can rotate a token for any agent:
 
 ```


### PR DESCRIPTION
## Summary
- add API Token menu for agents with show/rotate actions
- allow admins to view or rotate any agent's token
- document token management via Telegram bot

## Testing
- `python -m py_compile bot.py models/agents.py`


------
https://chatgpt.com/codex/tasks/task_b_68c59e49f3808328b6a0722fd90665a5