### PR TITLE
Add token retrieval endpoints for admins and agents

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -21,7 +21,7 @@ def get_admin_token():
         row = cur.fetchone()
     if not row:
         raise HTTPException(status_code=404, detail="Token not set")
-    return {"token": row["api_token"]}
+    return {"api_token": row["api_token"]}
 
 
 @router.post("/token", summary="Rotate admin token", dependencies=[Depends(require_super_admin)])
@@ -31,7 +31,7 @@ def rotate_admin_token():
         cur.execute("UPDATE admins SET api_token=%s WHERE is_super=1", (token,))
         if cur.rowcount == 0:
             cur.execute("INSERT INTO admins (api_token, is_super) VALUES (%s, 1)", (token,))
-    return {"token": token}
+    return {"api_token": token}
 
 
 # ---------------------- Panels ----------------------

--- a/api/main.py
+++ b/api/main.py
@@ -25,6 +25,15 @@ async def health_check():
     return {"status": "ok"}
 
 
+@router.get("/agents/{agent_id}/token")
+async def get_agent_token_endpoint(agent_id: int, _: None = Depends(require_admin)):
+    try:
+        token = get_api_token(agent_id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Token not found")
+    return {"api_token": token}
+
+
 @router.post("/agents/{agent_id}/token")
 async def rotate_agent_token_endpoint(agent_id: int, _: None = Depends(require_admin)):
     try:

--- a/docs/api.md
+++ b/docs/api.md
@@ -26,8 +26,7 @@ current token and generate a new one via the following endpoints:
 GET /api/v1/admin/token
 POST /api/v1/admin/token
 ```
-
-Use the returned `token` value as the bearer token for privileged requests.
+Use the returned `api_token` value as the bearer token for privileged requests.
 
 ### Agent tokens
 
@@ -50,9 +49,10 @@ Agents can also view or rotate their token directly from the Telegram bot via
 the **API Token** menu. Administrators may view or rotate any agent's token
 through the bot's agent management panel.
 
-Administrators can rotate a token for any agent:
+Administrators can view or rotate a token for any agent:
 
 ```
+GET /api/v1/agents/{agent_id}/token
 POST /api/v1/agents/{agent_id}/token
 ```
 


### PR DESCRIPTION
## Summary
- allow admins to view an agent's API token via a new GET endpoint
- return `api_token` for admin token endpoints for consistent responses
- document token management endpoints including new admin retrieval route

## Testing
- `pytest`
- `python -m py_compile api/admin.py api/main.py`


------
https://chatgpt.com/codex/tasks/task_b_68c5e380904083288e54f5fbad0e1a0f