### PR TITLE
Ensure agent tokens are always retrievable

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -30,7 +30,7 @@ async def get_agent_token_endpoint(agent_id: int, _: None = Depends(require_admi
     try:
         token = get_api_token(agent_id)
     except ValueError:
-        raise HTTPException(status_code=404, detail="Token not found")
+        raise HTTPException(status_code=404, detail="Agent not found")
     return {"api_token": token}
 
 
@@ -53,7 +53,7 @@ async def get_my_token(identity: Identity = Depends(require_agent)):
     try:
         token = get_api_token(row["id"])
     except ValueError:
-        raise HTTPException(status_code=404, detail="Token not found")
+        raise HTTPException(status_code=404, detail="Agent not found")
     return {"api_token": token}
 
 

--- a/bot.py
+++ b/bot.py
@@ -2126,9 +2126,11 @@ async def agent_show_token(update: Update, context: ContextTypes.DEFAULT_TYPE):
     try:
         tok = get_api_token(ag["id"])
     except Exception:
-        await q.edit_message_text("Token not found.")
-        return ConversationHandler.END
-    await context.bot.send_message(uid, f"Your API token:\n<code>{tok}</code>", parse_mode="HTML")
+        tok = rotate_api_token(ag["id"])
+        log.warning("Token missing for agent %s, generated a new one", uid)
+    await context.bot.send_message(
+        uid, f"Your API token:\n<code>{tok}</code>", parse_mode="HTML"
+    )
     log.info("Agent %s viewed API token", uid)
     return ConversationHandler.END
 
@@ -2158,9 +2160,13 @@ async def admin_show_agent_token(update: Update, context: ContextTypes.DEFAULT_T
     try:
         tok = get_api_token(a["id"])
     except Exception:
-        await q.edit_message_text("Token not found.")
-        return ConversationHandler.END
-    await context.bot.send_message(uid, f"Token for {a['name']}:\n<code>{tok}</code>", parse_mode="HTML")
+        tok = rotate_api_token(a["id"])
+        log.warning("Token missing for agent %s, generated a new one", atg)
+    await context.bot.send_message(
+        uid,
+        f"Token for {a['name']}:\n<code>{tok}</code>",
+        parse_mode="HTML",
+    )
     log.info("Admin %s viewed token for agent %s", uid, atg)
     return await show_agent_card(q, context, atg, notice="📨 Token sent via PM.")
 


### PR DESCRIPTION
## Summary
- Regenerate an API token automatically when an agent's token is missing
- Clarify API responses by returning `Agent not found` when appropriate

## Testing
- `pytest`
- `python -m py_compile api/main.py bot.py`


------
https://chatgpt.com/codex/tasks/task_b_68c5eb1fc7488328bde63e9a3188d40d