### PR TITLE
feat: allow admins to manage api token

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -47,7 +47,8 @@ POST /api/v1/agents/me/token
 
 Agents can also view or rotate their token directly from the Telegram bot via
 the **API Token** menu. Administrators may view or rotate any agent's token
-through the bot's agent management panel.
+through the bot's agent management panel. Super administrators can view or
+rotate the global admin token from the Admin Panel in the bot.
 
 Administrators can view or rotate a token for any agent:
 


### PR DESCRIPTION
## Summary
- add admin token management button to admin panel
- allow admins to view and rotate their own API token
- document admin token availability in bot

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68c5efae5f2c83288f93a9c9e6ad06dc