### PR TITLE
Fix owner ID parsing and dynamic admin owner resolution

### DIFF
--- a/api/users.py
+++ b/api/users.py
@@ -161,10 +161,19 @@ def list_users(
     offset: int = 0,
     limit: int = 25,
     service_id: int | None = None,
-    owner_id: int | None = None,
+    owner_id: int | None = Query(
+        None, description="Target agent ID (admin only)"
+    ),
+    ownerid: int | None = Query(
+        None, alias="ownerid", include_in_schema=False
+    ),
     identity: Identity = Depends(get_identity),
 ):
-    real_owner = identity.agent_id if identity.role == "agent" else owner_id
+    real_owner = (
+        identity.agent_id
+        if identity.role == "agent"
+        else (owner_id if owner_id is not None else ownerid)
+    )
     if real_owner is None:
         raise HTTPException(status_code=400, detail="owner_id required")
     rows, total = _list_users(real_owner, search, offset, limit, service_id)


### PR DESCRIPTION
## Summary
- fix `owner_id required` error when listing users by accepting `ownerid` alias and using Query params
- resolve admin owner IDs at request time so panel and settings APIs return data

## Testing
- `python -m py_compile api/users.py api/admin.py`


------
https://chatgpt.com/codex/tasks/task_b_68c6839bc3f48328ba542013afe763d9