### PR TITLE
Switch user listing to POST and accept JSON body

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -103,7 +103,10 @@ curl -X POST \
 ### List users
 
 ```sh
-curl -H "Authorization: Bearer $AGENT_TOKEN" \
+curl -X POST \
+  -H "Authorization: Bearer $AGENT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"owner_id":123,"offset":0,"limit":25}' \
   "http://localhost:${FLASK_PORT}/api/v1/users"
 ```
 
@@ -114,7 +117,7 @@ curl -X POST \
   -H "Authorization: Bearer $AGENT_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"username":"alice","limit_bytes":1073741824,"duration_days":30}' \
-  "http://localhost:${FLASK_PORT}/api/v1/users"
+  "http://localhost:${FLASK_PORT}/api/v1/users/create"
 ```
 
 ### Edit a user


### PR DESCRIPTION
## Summary
- Convert `/api/v1/users` listing endpoint to POST and read `owner_id`, `offset`, and `limit` from JSON body
- Move user creation to `/api/v1/users/create`
- Update API documentation to reflect new POST semantics

## Testing
- `python -m py_compile api/users.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68c6995b6f9c832884b164a6571adb49