### PR TITLE
Add activation key lookup endpoint

### DIFF
--- a/api/activation.py
+++ b/api/activation.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime
+
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel, Field
+
+from bot import with_mysql_cursor, get_app_key
+
+router = APIRouter(prefix="/activation", tags=["Activation"])
+
+
+class ActivationResponse(BaseModel):
+    """Activation lookup response payload."""
+
+    username: str = Field(..., description="Local username associated with the key")
+    plan_limit_bytes: int = Field(..., description="Configured traffic limit in bytes")
+    used_bytes: int = Field(..., description="Used traffic in bytes")
+    expire_at: datetime | None = Field(
+        None, description="When the subscription expires (UTC)")
+    disabled: bool = Field(..., description="Whether the user is currently disabled")
+    subscription_url: str = Field(..., description="Subscription link for the user")
+    key_expires_at: datetime | None = Field(
+        None, description="When this activation key expires (UTC)")
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "username": "alice",
+                "plan_limit_bytes": 107374182400,
+                "used_bytes": 53687091200,
+                "expire_at": "2024-12-31T23:59:59",
+                "disabled": False,
+                "subscription_url": "https://example.com/sub/alice/abcd1234/links",
+                "key_expires_at": "2024-12-01T00:00:00",
+            }
+        }
+    }
+
+
+@router.get("/{access_key}", response_model=ActivationResponse)
+def get_activation(access_key: str) -> ActivationResponse:
+    """Resolve a subscription activation key to user details."""
+
+    with with_mysql_cursor() as cur:
+        cur.execute(
+            """
+            SELECT
+                luk.expires_at,
+                lu.username,
+                lu.plan_limit_bytes,
+                lu.used_bytes,
+                lu.expire_at,
+                lu.disabled_pushed,
+                lu.owner_id
+            FROM local_user_keys AS luk
+            JOIN local_users AS lu ON lu.id = luk.local_user_id
+            WHERE luk.access_key=%s
+            LIMIT 1
+            """,
+            (access_key,),
+        )
+        row = cur.fetchone()
+
+    if not row:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Activation key not found",
+        )
+
+    expires_at = row.get("expires_at")
+    if expires_at and expires_at <= datetime.utcnow():
+        raise HTTPException(
+            status_code=status.HTTP_410_GONE,
+            detail="Activation key expired",
+        )
+
+    username = row["username"]
+    owner_id = int(row["owner_id"])
+    app_key = get_app_key(owner_id, username)
+    public_base = os.getenv("PUBLIC_BASE_URL", "http://localhost:5000").rstrip("/")
+    subscription_url = f"{public_base}/sub/{username}/{app_key}/links"
+
+    return ActivationResponse(
+        username=username,
+        plan_limit_bytes=int(row.get("plan_limit_bytes") or 0),
+        used_bytes=int(row.get("used_bytes") or 0),
+        expire_at=row.get("expire_at"),
+        disabled=bool(row.get("disabled_pushed")),
+        subscription_url=subscription_url,
+        key_expires_at=expires_at,
+    )
+
+
+__all__ = ("router",)

--- a/api/main.py
+++ b/api/main.py
@@ -9,6 +9,7 @@ from api.auth import require_admin, require_agent, Identity
 from api.admin import router as admin_router
 from api.users import router as users_router
 from api.sub import router as sub_router
+from api.activation import router as activation_router
 
 # FastAPI application that will also host the existing Flask app
 api_app = FastAPI()
@@ -17,6 +18,7 @@ router = APIRouter()
 router.include_router(admin_router)
 router.include_router(users_router)
 router.include_router(sub_router)
+router.include_router(activation_router)
 
 
 @router.get("/health")


### PR DESCRIPTION
## Summary
- add a public `/api/v1/activation/{access_key}` endpoint that fetches user metadata via activation keys
- return subscription details alongside usage data while rejecting invalid or expired keys
- register the activation router with the FastAPI application

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68c88027df8c8328a5b5c9ae6f686d1d