### PR TITLE
Add revocation controls for activation keys

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -255,12 +255,19 @@ def ensure_schema():
                 local_user_id BIGINT NOT NULL,
                 access_key VARCHAR(64) NOT NULL,
                 expires_at DATETIME NULL,
+                revoked_at DATETIME NULL,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 UNIQUE KEY uq_local_user(local_user_id),
                 UNIQUE KEY uq_access_key(access_key),
                 FOREIGN KEY (local_user_id) REFERENCES local_users(id) ON DELETE CASCADE
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
         """)
+        try:
+            cur.execute(
+                "ALTER TABLE local_user_keys ADD COLUMN revoked_at DATETIME NULL AFTER expires_at"
+            )
+        except MySQLError:
+            pass
         cur.execute("""
             CREATE TABLE IF NOT EXISTS local_user_panel_links(
                 id BIGINT AUTO_INCREMENT PRIMARY KEY,

--- a/docs/api.md
+++ b/docs/api.md
@@ -130,3 +130,25 @@ curl -X PATCH \
   "http://localhost:${FLASK_PORT}/api/v1/users/alice"
 ```
 
+### Revoke a user's activation key
+
+```sh
+curl -X POST \
+  -H "Authorization: Bearer $AGENT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"revoke":true}' \
+  "http://localhost:${FLASK_PORT}/api/v1/users/alice/keys/revoke"
+```
+
+Pass `{ "revoke": false }` in the body to restore a previously revoked key.
+
+### Purge expired activation keys
+
+```sh
+curl -X POST \
+  -H "Authorization: Bearer $AGENT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{}' \
+  "http://localhost:${FLASK_PORT}/api/v1/users/keys/purge-expired"
+```
+


### PR DESCRIPTION
## Summary
- add a `revoked_at` column to activation keys and ensure schema migrations cover existing tables
- block activation requests for revoked keys while surfacing revocation metadata in API responses
- expose endpoints and documentation for revoking keys, purging expired keys, and reporting revocation status in user details

## Testing
- python -m compileall api models bot.py
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68c881dc26c0832890915cf8e1ef8cc5