### PR TITLE
Add Pasarguard panel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ⚔️ ValhallaBot
 
-ValhallaBot is a self-hosted management stack for Marzneshin-, Marzban- and
-Sanaei-style panels. It combines a Telegram bot, a FastAPI/Flask web
+ValhallaBot is a self-hosted management stack for Marzneshin-, Marzban-, Sanaei-,
+and Pasarguard-style panels. It combines a Telegram bot, a FastAPI/Flask web
 application, and background workers to give administrators and agents unified
 control over subscriptions, usage limits, and automated provisioning.
 
@@ -128,7 +128,7 @@ can be added manually to customise behaviour.
 ## Using ValhallaBot
 
 - **Telegram bot** – Message your bot to open the inline menus. Admins can add
-  panels (Marzneshin, Marzban, Sanaei), create agents, assign services, rotate
+  panels (Marzneshin, Marzban, Sanaei, Pasarguard), create agents, assign services, rotate
   API tokens, and remove panels. Agents can provision local users, change
   quotas, renew subscriptions, and retrieve their unified subscription links.
 - **Subscription portal** – Each user receives a link of the form

--- a/apis/__init__.py
+++ b/apis/__init__.py
@@ -1,5 +1,5 @@
 """Collection of panel API client modules."""
 
-from . import marzneshin, marzban, sanaei
+from . import marzneshin, marzban, sanaei, pasarguard
 
-__all__ = ["marzneshin", "marzban", "sanaei"]
+__all__ = ["marzneshin", "marzban", "sanaei", "pasarguard"]

--- a/apis/pasarguard.py
+++ b/apis/pasarguard.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Helper functions for interacting with Pasarguard panel API."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Dict, List, Optional, Tuple
+from urllib.parse import urljoin
+
+import base64
+import os
+from threading import RLock
+
+import requests
+from cachetools import TTLCache, cached
+
+SESSION = requests.Session()
+ALLOWED_SCHEMES = ("vless://", "vmess://", "trojan://", "ss://")
+
+FETCH_CACHE_TTL = int(os.getenv("FETCH_CACHE_TTL", "300"))
+_links_cache = TTLCache(maxsize=256, ttl=FETCH_CACHE_TTL)
+_links_lock = RLock()
+
+
+def get_headers(token: str) -> Dict[str, str]:
+    """Return authorization header for the given bearer token."""
+    return {"Authorization": f"Bearer {token}"}
+
+
+def fetch_user_services(
+    panel_url: str, token: str, username: str
+) -> Tuple[Optional[List[int]], Optional[str]]:
+    """Pasarguard does not expose service IDs; return an empty list."""
+    return [], None
+
+
+def create_user(panel_url: str, token: str, payload: Dict) -> Tuple[Optional[Dict], Optional[str]]:
+    """Create a user on the remote panel."""
+    try:
+        r = SESSION.post(
+            urljoin(panel_url.rstrip("/") + "/", "api/user"),
+            json=payload,
+            headers={**get_headers(token), "Content-Type": "application/json"},
+            timeout=20,
+        )
+        if r.status_code in (200, 201):
+            return r.json(), None
+        return None, f"{r.status_code} {r.text[:300]}"
+    except Exception as e:  # pragma: no cover - network errors
+        return None, str(e)[:200]
+
+
+def get_user(panel_url: str, token: str, username: str) -> Tuple[Optional[Dict], Optional[str]]:
+    """Fetch user details from the panel."""
+    try:
+        r = SESSION.get(
+            urljoin(panel_url.rstrip("/") + "/", f"api/user/{username}"),
+            headers=get_headers(token),
+            timeout=15,
+        )
+        if r.status_code != 200:
+            return None, f"{r.status_code} {r.text[:200]}"
+        obj = r.json()
+        status = obj.get("status")
+        obj["enabled"] = status != "disabled"
+        sub_url = obj.get("subscription_url") or ""
+        token_part = sub_url.rstrip("/").split("/")[-1]
+        if token_part:
+            obj.setdefault("key", token_part)
+        return obj, None
+    except Exception as e:  # pragma: no cover - network errors
+        return None, str(e)[:200]
+
+
+def _extract_links(candidate: object) -> List[str]:
+    """Recursively extract subscription links from JSON structures."""
+    links: List[str] = []
+    if isinstance(candidate, str):
+        val = candidate.strip()
+        if val and val.lower().startswith(ALLOWED_SCHEMES):
+            links.append(val)
+    elif isinstance(candidate, Mapping):
+        for item in candidate.values():
+            links.extend(_extract_links(item))
+    elif isinstance(candidate, Iterable) and not isinstance(candidate, (bytes, bytearray)):
+        for item in candidate:
+            links.extend(_extract_links(item))
+    return links
+
+
+@cached(cache=_links_cache, lock=_links_lock)
+def fetch_links_from_panel(panel_url: str, username: str, key: str) -> List[str]:
+    """Return list of subscription links for a user token."""
+    try:
+        url = urljoin(panel_url.rstrip("/") + "/", f"sub/{key}/v2ray")
+        r = SESSION.get(url, headers={"accept": "text/plain"}, timeout=20)
+        if r.status_code == 200:
+            txt = (r.text or "").strip()
+            if txt:
+                try:
+                    decoded = base64.b64decode(txt + "===")
+                    txt = decoded.decode(errors="ignore")
+                except Exception:
+                    pass
+                lines = [ln.strip() for ln in txt.splitlines() if ln.strip()]
+                if any(ln.lower().startswith(ALLOWED_SCHEMES) for ln in lines):
+                    return lines
+        url = urljoin(panel_url.rstrip("/") + "/", f"sub/{key}/")
+        r = SESSION.get(
+            url,
+            headers={"accept": "application/json,text/plain"},
+            timeout=20,
+        )
+        if r.headers.get("content-type", "").startswith("application/json"):
+            try:
+                data = r.json()
+            except Exception:
+                data = None
+            if data is not None:
+                links = _extract_links(data)
+                if links:
+                    return links
+        if r.status_code == 200:
+            return [
+                ln.strip()
+                for ln in (r.text or "").splitlines()
+                if ln.strip() and ln.strip().lower().startswith(ALLOWED_SCHEMES)
+            ]
+        return []
+    except Exception:  # pragma: no cover - network errors
+        return []
+
+
+def disable_remote_user(panel_url: str, token: str, username: str) -> Tuple[bool, Optional[str]]:
+    """Disable a user on the panel."""
+    try:
+        r = SESSION.put(
+            urljoin(panel_url.rstrip("/") + "/", f"api/user/{username}"),
+            json={"status": "disabled"},
+            headers={**get_headers(token), "Content-Type": "application/json"},
+            timeout=20,
+        )
+        if r.status_code == 200:
+            return True, None
+        return False, f"{r.status_code} {r.text[:200]}"
+    except Exception as e:  # pragma: no cover - network errors
+        return False, str(e)[:200]
+
+
+def enable_remote_user(panel_url: str, token: str, username: str) -> Tuple[bool, Optional[str]]:
+    """Enable a user on the panel."""
+    try:
+        r = SESSION.put(
+            urljoin(panel_url.rstrip("/") + "/", f"api/user/{username}"),
+            json={"status": "active"},
+            headers={**get_headers(token), "Content-Type": "application/json"},
+            timeout=20,
+        )
+        if r.status_code == 200:
+            return True, None
+        return False, f"{r.status_code} {r.text[:200]}"
+    except Exception as e:  # pragma: no cover - network errors
+        return False, str(e)[:200]
+
+
+def remove_remote_user(panel_url: str, token: str, username: str) -> Tuple[bool, Optional[str]]:
+    """Delete a user on the panel."""
+    try:
+        r = SESSION.delete(
+            urljoin(panel_url.rstrip("/") + "/", f"api/user/{username}"),
+            headers=get_headers(token),
+            timeout=20,
+        )
+        if r.status_code in (200, 204):
+            return True, None
+        return False, f"{r.status_code} {r.text[:200]}"
+    except Exception as e:  # pragma: no cover - network errors
+        return False, str(e)[:200]
+
+
+def reset_remote_user_usage(panel_url: str, token: str, username: str) -> Tuple[bool, Optional[str]]:
+    """Reset traffic statistics for *username* on the panel."""
+    try:
+        r = SESSION.post(
+            urljoin(panel_url.rstrip("/") + "/", f"api/user/{username}/reset"),
+            headers=get_headers(token),
+            timeout=20,
+        )
+        if r.status_code == 200:
+            return True, None
+        return False, f"{r.status_code} {r.text[:200]}"
+    except Exception as e:  # pragma: no cover - network errors
+        return False, str(e)[:200]
+
+
+def update_remote_user(
+    panel_url: str,
+    token: str,
+    username: str,
+    data_limit: Optional[int] = None,
+    expire: Optional[int] = None,
+) -> Tuple[bool, Optional[str]]:
+    """Update quota or expiry for *username* on the panel."""
+    payload: Dict[str, object] = {}
+    if data_limit is not None:
+        payload["data_limit"] = int(data_limit)
+        payload["data_limit_reset_strategy"] = "no_reset"
+    if expire is not None:
+        payload["expire"] = int(expire)
+    if not payload:
+        return True, None
+    try:
+        r = SESSION.put(
+            urljoin(panel_url.rstrip("/") + "/", f"api/user/{username}"),
+            json=payload,
+            headers={**get_headers(token), "Content-Type": "application/json"},
+            timeout=20,
+        )
+        if r.status_code == 200:
+            return True, None
+        return False, f"{r.status_code} {r.text[:200]}"
+    except Exception as e:  # pragma: no cover - network errors
+        return False, str(e)[:200]
+
+
+def fetch_subscription_links(sub_url: str) -> List[str]:
+    """Return links from a subscription URL."""
+    try:
+        r = SESSION.get(
+            sub_url,
+            headers={"accept": "text/plain,application/json"},
+            timeout=20,
+        )
+        if r.headers.get("content-type", "").startswith("application/json"):
+            try:
+                data = r.json()
+            except Exception:
+                data = None
+            if data is not None:
+                links = _extract_links(data)
+                if links:
+                    return links
+        return [
+            ln.strip()
+            for ln in (r.text or "").splitlines()
+            if ln.strip() and ln.strip().lower().startswith(ALLOWED_SCHEMES)
+        ]
+    except Exception:  # pragma: no cover - network errors
+        return []
+
+
+def get_admin_token(panel_url: str, username: str, password: str) -> Tuple[Optional[str], Optional[str]]:
+    """Authenticate against the panel and return an access token."""
+    token_url = urljoin(panel_url.rstrip("/") + "/", "api/admin/token")
+    try:
+        resp = SESSION.post(
+            token_url,
+            data={"username": username, "password": password, "grant_type": "password"},
+            timeout=15,
+        )
+        if resp.status_code != 200:
+            return None, f"{resp.status_code} {resp.text[:200]}"
+        tok = (resp.json() or {}).get("access_token")
+        if not tok:
+            return None, "no access_token"
+        return tok, None
+    except Exception as e:  # pragma: no cover - network errors
+        return None, str(e)[:200]
+
+
+__all__ = [
+    "fetch_user_services",
+    "create_user",
+    "get_user",
+    "fetch_links_from_panel",
+    "disable_remote_user",
+    "enable_remote_user",
+    "remove_remote_user",
+    "reset_remote_user_usage",
+    "update_remote_user",
+    "fetch_subscription_links",
+    "get_admin_token",
+]

--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-Flask subscription aggregator for Marzneshin/Marzban panels
+Flask subscription aggregator for Marzneshin/Marzban/Sanaei/Pasarguard panels
 - GET /sub/<local_username>/<app_key>/links
 - Returns only configs (ss://, vless://, vmess://, trojan://), one per line (text/plain)
 - Enforces local quota. If user quota exceeded -> empty body + DISABLE remote (once).

--- a/bot.py
+++ b/bot.py
@@ -37,7 +37,7 @@ import asyncio
 from dotenv import load_dotenv
 from mysql.connector import pooling, Error as MySQLError
 
-from apis import marzneshin, marzban, sanaei
+from apis import marzneshin, marzban, sanaei, pasarguard
 
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import (
@@ -60,6 +60,7 @@ API_MODULES = {
     "marzneshin": marzneshin,
     "marzban": marzban,
     "sanaei": sanaei,
+    "pasarguard": pasarguard,
 }
 
 def get_api(panel_type: str):
@@ -2413,15 +2414,15 @@ async def got_panel_name(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await update.message.reply_text("❌ اسم معتبر بفرست:")
         return ASK_PANEL_NAME
     context.user_data["panel_name"] = name
-    await update.message.reply_text("نوع پنل را مشخص کن (marzneshin/marzban/sanaei):")
+    await update.message.reply_text("نوع پنل را مشخص کن (marzneshin/marzban/sanaei/pasarguard):")
     return ASK_PANEL_TYPE
 
 async def got_panel_type(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if not is_admin(update.effective_user.id):
         return ConversationHandler.END
     t = (update.message.text or "").strip().lower()
-    if t not in ("marzneshin", "marzban", "sanaei"):
-        await update.message.reply_text("❌ نوع پنل نامعتبر. یکی از marzneshin/marzban/sanaei بفرست:")
+    if t not in ("marzneshin", "marzban", "sanaei", "pasarguard"):
+        await update.message.reply_text("❌ نوع پنل نامعتبر. یکی از marzneshin/marzban/sanaei/pasarguard بفرست:")
         return ASK_PANEL_TYPE
     context.user_data["panel_type"] = t
     await update.message.reply_text("🌐 URL پنل (مثال https://panel.example.com):")

--- a/scripts/usage_sync.py
+++ b/scripts/usage_sync.py
@@ -11,7 +11,7 @@ from dotenv import load_dotenv
 from mysql.connector import pooling
 import mysql.connector
 
-from apis import marzneshin, marzban, sanaei
+from apis import marzneshin, marzban, sanaei, pasarguard
 
 logging.basicConfig(
     format="%(asctime)s | %(levelname)s | usage_sync | %(message)s",
@@ -25,6 +25,7 @@ API_MODULES = {
     "marzneshin": marzneshin,
     "marzban": marzban,
     "sanaei": sanaei,
+    "pasarguard": pasarguard,
 }
 
 


### PR DESCRIPTION
## Summary
- add a Pasarguard API client that mirrors user, subscription, and admin token helpers
- allow the bot and usage sync worker to use the Pasarguard backend and update prompts accordingly
- document Pasarguard as a supported panel in the README and aggregator module docstring

## Testing
- python -m compileall apis bot.py scripts/usage_sync.py app.py

------
https://chatgpt.com/codex/tasks/task_b_68d4e542297c832890cc2d25f6812ea2