### PR TITLE
Revamp web login and users pages with React TypeScript UI

### DIFF
--- a/api/subscription_aggregator/static/web-ui.css
+++ b/api/subscription_aggregator/static/web-ui.css
@@ -1,0 +1,147 @@
+:root {
+  color-scheme: dark;
+  --bg-a: #080d19;
+  --bg-b: #13213f;
+  --panel: rgba(13, 22, 44, 0.82);
+  --panel-strong: rgba(16, 27, 54, 0.92);
+  --text: #f4f8ff;
+  --muted: #a2b2d1;
+  --primary: #4f8cff;
+  --primary-2: #34d3ff;
+  --danger: #ff6f91;
+  --line: rgba(136, 163, 220, 0.24);
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+  color: var(--text);
+  background: radial-gradient(circle at top, #193063 0%, var(--bg-a) 45%, #060a13 100%);
+}
+
+.vb-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+}
+
+.vb-login-card,
+.vb-users-card {
+  width: min(100%, 1120px);
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  backdrop-filter: blur(12px);
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.35);
+}
+
+.vb-login-card {
+  max-width: 520px;
+  padding: 34px;
+}
+
+.vb-chip {
+  display: inline-flex;
+  margin: 0 0 8px;
+  padding: 7px 12px;
+  border-radius: 999px;
+  background: rgba(79, 140, 255, 0.18);
+  border: 1px solid rgba(79, 140, 255, 0.45);
+  color: #b7d2ff;
+  font-weight: 600;
+  font-size: 12px;
+}
+
+h1 { margin: 0; font-size: 2rem; }
+.vb-subtitle { color: var(--muted); margin: 10px 0 0; }
+
+.vb-form { display: grid; gap: 14px; margin-top: 22px; }
+.vb-form label { display: grid; gap: 7px; font-size: 14px; color: #d5e2ff; }
+input {
+  width: 100%;
+  background: var(--panel-strong);
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  font-size: 14px;
+  padding: 11px 12px;
+  outline: none;
+}
+input:focus {
+  border-color: rgba(79, 140, 255, 0.9);
+  box-shadow: 0 0 0 3px rgba(79, 140, 255, 0.2);
+}
+
+button {
+  border: 0;
+  border-radius: 12px;
+  padding: 11px 14px;
+  font-weight: 700;
+  cursor: pointer;
+  color: #fff;
+  background: linear-gradient(120deg, var(--primary), var(--primary-2));
+}
+button:disabled { opacity: 0.6; cursor: wait; }
+.vb-secondary-btn {
+  width: fit-content;
+  background: rgba(162, 178, 209, 0.18);
+  border: 1px solid var(--line);
+}
+
+.vb-error { margin: 2px 0 0; color: var(--danger); }
+.vb-hint { margin: 2px 0 0; color: var(--muted); font-size: 13px; }
+
+.vb-users-shell { align-items: start; }
+.vb-users-card { margin: 28px auto; padding: 24px; }
+.vb-users-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 14px;
+}
+
+.vb-stat-grid {
+  margin-top: 18px;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+.vb-stat-grid article {
+  padding: 14px;
+  border-radius: 14px;
+  background: rgba(13, 24, 49, 0.75);
+  border: 1px solid var(--line);
+}
+.vb-stat-grid span { color: var(--muted); font-size: 13px; }
+.vb-stat-grid strong { display: block; margin-top: 6px; font-size: 1.28rem; }
+
+.vb-table-toolbar { margin-top: 14px; }
+.vb-table-wrap {
+  margin-top: 14px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  overflow: auto;
+}
+
+table { width: 100%; border-collapse: collapse; min-width: 760px; }
+th, td { text-align: left; padding: 12px 14px; border-bottom: 1px solid rgba(136, 163, 220, 0.14); }
+th { color: #c8d8fa; font-size: 13px; background: rgba(17, 31, 61, 0.95); position: sticky; top: 0; }
+td { font-size: 14px; color: #eff3ff; }
+
+.vb-badge {
+  display: inline-flex;
+  border-radius: 999px;
+  padding: 5px 10px;
+  font-size: 12px;
+  font-weight: 700;
+}
+.vb-badge.success { background: rgba(64, 200, 154, 0.15); color: #5ce7bb; border: 1px solid rgba(64, 200, 154, 0.4); }
+.vb-badge.danger { background: rgba(255, 111, 145, 0.14); color: #ff8bab; border: 1px solid rgba(255, 111, 145, 0.35); }
+
+@media (max-width: 760px) {
+  .vb-login-card { padding: 24px; }
+  .vb-users-header { flex-direction: column; }
+  .vb-stat-grid { grid-template-columns: 1fr; }
+}

--- a/api/subscription_aggregator/static/web-ui.tsx
+++ b/api/subscription_aggregator/static/web-ui.tsx
@@ -1,0 +1,243 @@
+type PageMode = 'login' | 'users';
+
+type UserRecord = {
+  username: string;
+  plan_limit_bytes: number;
+  used_bytes: number;
+  expire_at?: string | null;
+  disabled: boolean;
+};
+
+type UsersResponse = {
+  total: number;
+  users: UserRecord[];
+};
+
+const { useEffect, useMemo, useState } = React;
+const numberFormatter = new Intl.NumberFormat();
+
+function formatBytes(value?: number | null): string {
+  if (value === null || value === undefined) return '-';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let num = Number(value);
+  let idx = 0;
+  while (num >= 1024 && idx < units.length - 1) {
+    num /= 1024;
+    idx += 1;
+  }
+  return `${num.toFixed(idx === 0 ? 0 : 2)} ${units[idx]}`;
+}
+
+function parseDate(value?: string | null): string {
+  if (!value) return '-';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
+}
+
+function LoginPage() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/v1/web/me', { credentials: 'same-origin' })
+      .then((res) => {
+        if (res.ok) {
+          window.location.replace('/web/users');
+        }
+      })
+      .catch(() => undefined);
+  }, []);
+
+  const submit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setError('');
+    setBusy(true);
+    try {
+      const res = await fetch('/api/v1/web/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'same-origin',
+        body: JSON.stringify({ username, password }),
+      });
+
+      if (res.ok) {
+        window.location.replace('/web/users');
+        return;
+      }
+      if (res.status === 429) {
+        setError('Too many login attempts. Please wait a bit and try again.');
+        return;
+      }
+      setError('Invalid username or password.');
+    } catch {
+      setError('Unable to login right now. Please try again.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <main className="vb-shell">
+      <section className="vb-login-card">
+        <p className="vb-chip">Valhalla Web Console</p>
+        <h1>Welcome back</h1>
+        <p className="vb-subtitle">Sign in to securely manage users, quotas, and expiration dates.</p>
+        <form onSubmit={submit} className="vb-form">
+          <label>
+            Username
+            <input
+              value={username}
+              onChange={(event) => setUsername(event.target.value)}
+              autoComplete="username"
+              required
+              placeholder="Enter your username"
+            />
+          </label>
+          <label>
+            Password
+            <input
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              autoComplete="current-password"
+              type="password"
+              required
+              placeholder="Enter your password"
+            />
+          </label>
+          <button type="submit" disabled={busy}>{busy ? 'Signing in…' : 'Sign in'}</button>
+          {error ? <p className="vb-error">{error}</p> : <p className="vb-hint">Session is protected with secure HTTP-only cookies.</p>}
+        </form>
+      </section>
+    </main>
+  );
+}
+
+function UsersPage() {
+  const [users, setUsers] = useState<UserRecord[]>([]);
+  const [search, setSearch] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const boot = async () => {
+      try {
+        const meRes = await fetch('/api/v1/web/me', { credentials: 'same-origin' });
+        if (!meRes.ok) {
+          window.location.replace('/web/login');
+          return;
+        }
+
+        const usersRes = await fetch('/api/v1/web/users?limit=200', { credentials: 'same-origin' });
+        if (usersRes.status === 401) {
+          window.location.replace('/web/login');
+          return;
+        }
+        if (!usersRes.ok) {
+          throw new Error('load failed');
+        }
+        const data = (await usersRes.json()) as UsersResponse;
+        setUsers(Array.isArray(data.users) ? data.users : []);
+      } catch {
+        setError('Unable to load users right now.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    void boot();
+  }, []);
+
+  const filteredUsers = useMemo(
+    () => users.filter((user) => user.username.toLowerCase().includes(search.trim().toLowerCase())),
+    [search, users],
+  );
+
+  const stats = useMemo(() => {
+    const totalUsage = users.reduce((sum, user) => sum + (user.used_bytes || 0), 0);
+    const disabled = users.filter((user) => user.disabled).length;
+    return { totalUsers: users.length, disabled, totalUsage };
+  }, [users]);
+
+  const logout = async () => {
+    try {
+      await fetch('/api/v1/web/logout', { method: 'POST', credentials: 'same-origin' });
+    } finally {
+      window.location.replace('/web/login');
+    }
+  };
+
+  return (
+    <main className="vb-shell vb-users-shell">
+      <section className="vb-users-card">
+        <header className="vb-users-header">
+          <div>
+            <p className="vb-chip">Valhalla Dashboard</p>
+            <h1>Users</h1>
+            <p className="vb-subtitle">Monitor quota usage and account status in one place.</p>
+          </div>
+          <button type="button" onClick={logout} className="vb-secondary-btn">Logout</button>
+        </header>
+
+        <section className="vb-stat-grid">
+          <article><span>Total users</span><strong>{numberFormatter.format(stats.totalUsers)}</strong></article>
+          <article><span>Disabled users</span><strong>{numberFormatter.format(stats.disabled)}</strong></article>
+          <article><span>Total usage</span><strong>{formatBytes(stats.totalUsage)}</strong></article>
+        </section>
+
+        <div className="vb-table-toolbar">
+          <input
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Search by username"
+            aria-label="Search by username"
+          />
+        </div>
+
+        {error ? <p className="vb-error">{error}</p> : null}
+
+        <div className="vb-table-wrap">
+          <table>
+            <thead>
+              <tr><th>Username</th><th>Plan limit</th><th>Used</th><th>Expires at</th><th>Status</th></tr>
+            </thead>
+            <tbody>
+              {loading ? (
+                <tr><td colSpan={5}>Loading users…</td></tr>
+              ) : filteredUsers.length === 0 ? (
+                <tr><td colSpan={5}>No users found.</td></tr>
+              ) : (
+                filteredUsers.map((user) => (
+                  <tr key={user.username}>
+                    <td>{user.username}</td>
+                    <td>{formatBytes(user.plan_limit_bytes)}</td>
+                    <td>{formatBytes(user.used_bytes)}</td>
+                    <td>{parseDate(user.expire_at)}</td>
+                    <td>
+                      <span className={user.disabled ? 'vb-badge danger' : 'vb-badge success'}>
+                        {user.disabled ? 'Disabled' : 'Active'}
+                      </span>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+function App() {
+  const page = document.body.dataset.page as PageMode;
+  if (page === 'users') return <UsersPage />;
+  return <LoginPage />;
+}
+
+const rootNode = document.getElementById('root');
+if (rootNode) {
+  ReactDOM.createRoot(rootNode).render(<App />);
+}

--- a/templates/web_login.html
+++ b/templates/web_login.html
@@ -3,75 +3,14 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Web Login</title>
-  <style>
-    body { font-family: Arial, sans-serif; margin: 2rem; background: #f7f7f8; }
-    .card { max-width: 360px; margin: 0 auto; background: #fff; border-radius: 8px; padding: 1.25rem; box-shadow: 0 2px 10px rgba(0,0,0,.08); }
-    h1 { margin-top: 0; font-size: 1.25rem; }
-    label { display: block; margin-top: .75rem; font-size: .9rem; }
-    input { width: 100%; box-sizing: border-box; margin-top: .35rem; padding: .55rem; }
-    button { margin-top: 1rem; width: 100%; padding: .6rem; cursor: pointer; }
-    .error { color: #b00020; font-size: .9rem; margin-top: .75rem; min-height: 1.2rem; }
-  </style>
+  <title>Valhalla Web Login</title>
+  <link rel="stylesheet" href="/static/web-ui.css" />
 </head>
-<body>
-  <div class="card">
-    <h1>Sign in</h1>
-    <form id="login-form">
-      <label for="username">Username</label>
-      <input id="username" name="username" autocomplete="username" required />
-
-      <label for="password">Password</label>
-      <input id="password" name="password" type="password" autocomplete="current-password" required />
-
-      <button type="submit">Login</button>
-      <div id="error" class="error"></div>
-    </form>
-  </div>
-
-  <script>
-    async function checkExistingSession() {
-      try {
-        const response = await fetch('/api/v1/web/me', { credentials: 'same-origin' });
-        if (response.ok) {
-          window.location.replace('/web/users');
-        }
-      } catch (_error) {
-        // Ignore network errors and keep login form visible.
-      }
-    }
-
-    async function onSubmit(event) {
-      event.preventDefault();
-      const errorNode = document.getElementById('error');
-      errorNode.textContent = '';
-
-      const payload = {
-        username: document.getElementById('username').value,
-        password: document.getElementById('password').value,
-      };
-
-      try {
-        const response = await fetch('/api/v1/web/login', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          credentials: 'same-origin',
-          body: JSON.stringify(payload),
-        });
-
-        if (!response.ok) {
-          errorNode.textContent = 'Invalid username or password.';
-          return;
-        }
-
-        window.location.replace('/web/users');
-      } catch (_error) {
-        errorNode.textContent = 'Unable to login right now. Please try again.';
-      }
-    }
-
-    document.getElementById('login-form').addEventListener('submit', onSubmit);
-    checkExistingSession();
-  </script>
+<body data-page="login">
+  <div id="root"></div>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script type="text/babel" data-type="module" data-presets="typescript,react" src="/static/web-ui.tsx"></script>
 </body>
 </html>

--- a/templates/web_users.html
+++ b/templates/web_users.html
@@ -3,123 +3,14 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Users</title>
-  <style>
-    body { font-family: Arial, sans-serif; margin: 2rem; background: #f7f7f8; }
-    .container { max-width: 980px; margin: 0 auto; }
-    .toolbar { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; }
-    h1 { margin: 0; font-size: 1.4rem; }
-    button { padding: .5rem .85rem; cursor: pointer; }
-    table { width: 100%; border-collapse: collapse; background: #fff; box-shadow: 0 2px 10px rgba(0,0,0,.08); }
-    th, td { text-align: left; padding: .6rem; border-bottom: 1px solid #ececec; font-size: .92rem; }
-    th { background: #fafafa; }
-    .muted { color: #666; }
-    .error { color: #b00020; margin-bottom: .75rem; }
-  </style>
+  <title>Valhalla Users</title>
+  <link rel="stylesheet" href="/static/web-ui.css" />
 </head>
-<body>
-  <div class="container">
-    <div class="toolbar">
-      <h1>Users</h1>
-      <button id="logout-btn" type="button">Logout</button>
-    </div>
-    <div id="error" class="error"></div>
-    <table>
-      <thead>
-        <tr>
-          <th>Username</th>
-          <th>Plan limit (bytes)</th>
-          <th>Used bytes</th>
-          <th>Expire date</th>
-          <th>Disabled</th>
-        </tr>
-      </thead>
-      <tbody id="users-body">
-        <tr><td colspan="5" class="muted">Loading…</td></tr>
-      </tbody>
-    </table>
-  </div>
-
-  <script>
-    function toText(value, fallback = '-') {
-      if (value === null || value === undefined || value === '') {
-        return fallback;
-      }
-      return String(value);
-    }
-
-    async function requireAuth() {
-      const meResponse = await fetch('/api/v1/web/me', { credentials: 'same-origin' });
-      if (!meResponse.ok) {
-        window.location.replace('/web/login');
-        throw new Error('Unauthenticated');
-      }
-    }
-
-    function renderUsers(users) {
-      const tbody = document.getElementById('users-body');
-      if (!Array.isArray(users) || users.length === 0) {
-        tbody.innerHTML = '<tr><td colspan="5" class="muted">No users found.</td></tr>';
-        return;
-      }
-
-      tbody.innerHTML = '';
-      users.forEach((user) => {
-        const tr = document.createElement('tr');
-
-        [
-          toText(user.username),
-          toText(user.plan_limit_bytes, '0'),
-          toText(user.used_bytes, '0'),
-          toText(user.expire_at),
-          user.disabled ? 'Yes' : 'No',
-        ].forEach((value) => {
-          const td = document.createElement('td');
-          td.textContent = value;
-          tr.appendChild(td);
-        });
-
-        tbody.appendChild(tr);
-      });
-    }
-
-    async function loadUsers() {
-      await requireAuth();
-
-      const response = await fetch('/api/v1/web/users', {
-        credentials: 'same-origin',
-      });
-
-      if (response.status === 401) {
-        window.location.replace('/web/login');
-        return;
-      }
-
-      if (!response.ok) {
-        throw new Error('Failed to load users');
-      }
-
-      const data = await response.json();
-      renderUsers(data.users || []);
-    }
-
-    async function logout() {
-      try {
-        await fetch('/api/v1/web/logout', {
-          method: 'POST',
-          credentials: 'same-origin',
-        });
-      } finally {
-        window.location.replace('/web/login');
-      }
-    }
-
-    document.getElementById('logout-btn').addEventListener('click', logout);
-
-    loadUsers().catch(() => {
-      const errorNode = document.getElementById('error');
-      errorNode.textContent = 'Unable to load users right now.';
-    });
-  </script>
+<body data-page="users">
+  <div id="root"></div>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script type="text/babel" data-type="module" data-presets="typescript,react" src="/static/web-ui.tsx"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Replace minimal, inline-script HTML pages with a modern, maintainable TypeScript + React UI to greatly improve the web login and users experience. 
- Provide a single shared client app for login, session checks, users listing, search and basic dashboard stats while keeping backend APIs unchanged. 

### Description
- Replaced `templates/web_login.html` and `templates/web_users.html` with lightweight entry pages that mount a client app and load React/Babel in-browser (`data-page` attribute selects the page mode). 
- Added a single client-side TypeScript React app at `api/subscription_aggregator/static/web-ui.tsx` that implements login flow, session check, user list fetching, search, stats (total users, disabled, total usage), and logout behavior. 
- Added a modern stylesheet `api/subscription_aggregator/static/web-ui.css` (dark glassmorphism look, responsive layout, badges, table styling) and wired it into the new templates. 
- Kept all backend routes and authentication logic intact; served the new UI as static files from the existing aggregator without changing API contracts. 
- Implementation note: an initial attempt to bundle the frontend with `esbuild` via a local `frontend/` build step failed due to `npm` access restrictions, so the delivered approach uses an in-browser TSX entry served under `/static/web-ui.tsx` and loads React and Babel from unpkg for progressive enhancement.

### Testing
- Ran `python -m compileall api` to ensure Python modules import cleanly, and it completed successfully. 
- Attempted to build the npm-based bundle (`npm --prefix frontend install`) but the run failed due to a `403` when fetching `esbuild` from the registry, so no local bundle was produced. 
- Attempted a Playwright navigation/screenshot to `http://127.0.0.1:5000/web/login` to validate runtime rendering, but the request failed with `ERR_EMPTY_RESPONSE` because the application server was not running in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699f5d5752ac8327b1f57a5aae073b56)