### PR TITLE
Refresh web UI to monochrome theme and add left-side hamburger sidebar

### DIFF
--- a/api/subscription_aggregator/static/web-ui.tsx
+++ b/api/subscription_aggregator/static/web-ui.tsx
@@ -65,10 +65,10 @@ function parseDate(value?: string | null): string {
   return date.toLocaleString();
 }
 
-const cardClass = 'rounded-2xl border border-slate-200/80 bg-white/90 p-6 shadow-2xl shadow-slate-900/10 backdrop-blur dark:border-slate-700 dark:bg-slate-900/80 dark:shadow-black/30';
-const inputClass = 'w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm text-slate-900 outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100';
+const cardClass = 'rounded-2xl border border-slate-200/80 bg-white/95 p-6 shadow-2xl shadow-slate-900/10 backdrop-blur dark:border-slate-700 dark:bg-slate-900/90 dark:shadow-black/30';
+const inputClass = 'w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm text-slate-900 outline-none transition focus:border-slate-900 focus:ring-2 focus:ring-slate-400/30 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:focus:border-slate-200 dark:focus:ring-slate-500/30';
 const secondaryButtonClass = 'rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700';
-const primaryButtonClass = 'rounded-xl bg-gradient-to-r from-indigo-600 to-violet-600 px-4 py-2.5 text-sm font-semibold text-white transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60';
+const primaryButtonClass = 'rounded-xl bg-slate-900 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-black disabled:cursor-not-allowed disabled:opacity-60 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-white';
 
 function LoginPage() {
   const { theme, toggleTheme } = useTheme();
@@ -116,11 +116,11 @@ function LoginPage() {
   };
 
   return (
-    <main className="min-h-screen bg-gradient-to-br from-slate-100 via-indigo-100 to-violet-100 p-4 dark:from-slate-950 dark:via-slate-900 dark:to-indigo-950">
+    <main className="min-h-screen bg-gradient-to-br from-white via-slate-100 to-slate-200 p-4 dark:from-slate-950 dark:via-slate-900 dark:to-black">
       <section className="mx-auto mt-12 max-w-md">
         <div className={cardClass}>
           <div className="mb-4 flex items-center justify-between gap-3">
-            <span className="rounded-full bg-indigo-50 px-3 py-1 text-xs font-semibold text-indigo-700 dark:bg-indigo-500/20 dark:text-indigo-200">
+            <span className="rounded-full bg-slate-200 px-3 py-1 text-xs font-semibold text-slate-800 dark:bg-slate-700 dark:text-slate-100">
               Valhalla Web Console
             </span>
             <button type="button" className={secondaryButtonClass} onClick={toggleTheme}>
@@ -166,6 +166,7 @@ function LoginPage() {
 
 function UsersPage() {
   const { theme, toggleTheme } = useTheme();
+  const [sidebarOpen, setSidebarOpen] = useState(false);
   const [users, setUsers] = useState<UserRecord[]>([]);
   const [totalUsageBytes, setTotalUsageBytes] = useState(0);
   const [search, setSearch] = useState('');
@@ -363,11 +364,33 @@ function UsersPage() {
   };
 
   return (
-    <main className="min-h-screen bg-gradient-to-br from-slate-100 via-indigo-100 to-violet-100 p-4 dark:from-slate-950 dark:via-slate-900 dark:to-indigo-950">
+    <main className="min-h-screen bg-gradient-to-br from-white via-slate-100 to-slate-200 p-4 dark:from-slate-950 dark:via-slate-900 dark:to-black">
       <section className={`mx-auto max-w-6xl ${cardClass}`}>
+        <div className="flex gap-4">
+          <aside className={`fixed inset-y-0 left-0 z-40 w-64 border-r border-slate-200 bg-white/95 p-4 shadow-xl transition-transform duration-200 dark:border-slate-700 dark:bg-slate-900/95 md:static md:translate-x-0 md:rounded-xl md:shadow-none ${sidebarOpen ? 'translate-x-0' : '-translate-x-full'}`}>
+            <div className="mb-5 flex items-center justify-between md:justify-start">
+              <p className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-300">Navigation</p>
+              <button type="button" className="md:hidden rounded-lg border border-slate-300 px-2 py-1 text-slate-700 dark:border-slate-600 dark:text-slate-100" onClick={() => setSidebarOpen(false)}>✕</button>
+            </div>
+            <nav className="space-y-2">
+              <a href="#" className="block rounded-lg bg-slate-900 px-3 py-2 text-sm font-medium text-white dark:bg-slate-100 dark:text-slate-900">Users</a>
+              <span className="block rounded-lg border border-dashed border-slate-300 px-3 py-2 text-sm text-slate-500 dark:border-slate-600 dark:text-slate-300">Add future section</span>
+            </nav>
+          </aside>
+          {sidebarOpen ? <div className="fixed inset-0 z-30 bg-black/40 md:hidden" onClick={() => setSidebarOpen(false)} /> : null}
+
+          <div className="w-full">
         <header className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
           <div>
-            <span className="rounded-full bg-indigo-50 px-3 py-1 text-xs font-semibold text-indigo-700 dark:bg-indigo-500/20 dark:text-indigo-200">Valhalla Dashboard</span>
+            <button type="button" onClick={() => setSidebarOpen((prev) => !prev)} className="mb-3 inline-flex items-center gap-2 rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-700 shadow-sm hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700 md:hidden">
+              <span className="space-y-1">
+                <span className="block h-0.5 w-4 bg-current" />
+                <span className="block h-0.5 w-4 bg-current" />
+                <span className="block h-0.5 w-4 bg-current" />
+              </span>
+              Menu
+            </button>
+            <span className="rounded-full bg-slate-200 px-3 py-1 text-xs font-semibold text-slate-800 dark:bg-slate-700 dark:text-slate-100">Valhalla Dashboard</span>
             <h1 className="mt-3 text-3xl font-bold text-slate-900 dark:text-white">Users</h1>
             <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">Monitor quota usage and account status in one place.</p>
           </div>
@@ -506,6 +529,8 @@ function UsersPage() {
             </section>
           </div>
         ) : null}
+          </div>
+        </div>
       </section>
     </main>
   );

--- a/templates/web_login.html
+++ b/templates/web_login.html
@@ -9,24 +9,24 @@
     tailwind.config = { darkMode: 'class' }
   </script>
 </head>
-<body class="min-h-screen bg-gradient-to-br from-slate-100 via-indigo-100 to-violet-100 p-4 dark:from-slate-950 dark:via-slate-900 dark:to-indigo-950">
+<body class="min-h-screen bg-gradient-to-br from-white via-slate-100 to-slate-200 p-4 dark:from-slate-950 dark:via-slate-900 dark:to-black">
   <main class="flex min-h-screen items-center justify-center">
     <section class="w-full max-w-md rounded-2xl border border-slate-200/80 bg-white/90 p-6 shadow-2xl shadow-slate-900/10 backdrop-blur dark:border-slate-700 dark:bg-slate-900/80 dark:shadow-black/30">
-      <div class="mb-4 rounded-full bg-indigo-50 px-3 py-1 text-xs font-semibold text-indigo-700 dark:bg-indigo-500/20 dark:text-indigo-200 w-fit">Valhalla Admin Login</div>
+      <div class="mb-4 rounded-full bg-slate-200 px-3 py-1 text-xs font-semibold text-slate-800 dark:bg-slate-700 dark:text-slate-100 w-fit">Valhalla Admin Login</div>
       <h1 class="text-3xl font-bold text-slate-900 dark:text-white">Welcome back</h1>
       <p class="mt-2 text-sm text-slate-600 dark:text-slate-300">Sign in to manage users and quotas.</p>
 
       <form id="login-form" class="mt-6 space-y-4">
         <label class="block text-sm font-medium text-slate-700 dark:text-slate-200">
           Username
-          <input id="username" class="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm text-slate-900 outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100" autocomplete="username" required />
+          <input id="username" class="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm text-slate-900 outline-none transition focus:border-slate-900 focus:ring-2 focus:ring-slate-400/30 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:focus:border-slate-200 dark:focus:ring-slate-500/30" autocomplete="username" required />
         </label>
         <label class="block text-sm font-medium text-slate-700 dark:text-slate-200">
           Password
-          <input id="password" class="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm text-slate-900 outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100" type="password" autocomplete="current-password" required />
+          <input id="password" class="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm text-slate-900 outline-none transition focus:border-slate-900 focus:ring-2 focus:ring-slate-400/30 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:focus:border-slate-200 dark:focus:ring-slate-500/30" type="password" autocomplete="current-password" required />
         </label>
         <p id="error" class="hidden text-sm font-medium text-rose-500"></p>
-        <button id="submit" type="submit" class="w-full rounded-xl bg-gradient-to-r from-indigo-600 to-violet-600 px-4 py-2.5 text-sm font-semibold text-white transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60">Sign in</button>
+        <button id="submit" type="submit" class="w-full rounded-xl bg-slate-900 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-black disabled:cursor-not-allowed disabled:opacity-60 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-white">Sign in</button>
       </form>
     </section>
   </main>


### PR DESCRIPTION
### Motivation
- Modernize the admin UI to a strict black/white (monochrome) palette and remove the previous indigo/violet accents. 
- Make the dashboard ready for future expansion by adding a left-side navigation area and a mobile-friendly hamburger toggle. 
- Use Tailwind utility tokens consistently so inputs, cards and buttons share a unified monochrome look while keeping dark/light compatibility.

### Description
- Reworked reusable Tailwind class tokens in `api/subscription_aggregator/static/web-ui.tsx` (updated `cardClass`, `inputClass`, and `primaryButtonClass`) to adopt slate/black/white styling and updated input focus colors. 
- Replaced login and dashboard background gradients that used indigo/violet with white/slate/black gradients and adjusted badges/buttons to slate/black variants in both the React UI and the standalone login template. 
- Added a left-side navigation `aside` to the users dashboard with a slide-in mobile hamburger, overlay backdrop, and a `sidebarOpen` state to toggle visibility, plus a placeholder nav entry to allow adding future sections easily. 
- Updated `templates/web_login.html` to match the new monochrome tokens and focus styles so the standalone login page matches the React console.

### Testing
- Ran a code search with `rg -n "indigo|violet|purple" api/subscription_aggregator/static/web-ui.tsx templates/web_login.html templates/web_users.html` and found no remaining indigo/violet references. 
- Attempted to start the app with `python app.py` for manual verification, but startup failed in this environment due to MySQL pool configuration (`Pool size should be higher than 0 and lower or equal to 32`), so visual runtime verification could not be completed. 
- Verified the diffs of the two modified files and ensured the updated Tailwind classes are syntactically valid in the JSX/HTML contexts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a0bbbe5b68832781a3ffa8e6b6c08b)