### PR TITLE
Restore full-width High Usage insight on mobile in Users tab

### DIFF
--- a/api/subscription_aggregator/static/web-ui.tsx
+++ b/api/subscription_aggregator/static/web-ui.tsx
@@ -336,12 +336,12 @@ function TopBar({
   );
 }
 
-function InsightCard({ label, value, icon, trend, trendUp, onClick }: { label: string; value: string | number; icon: string; trend?: string; trendUp?: boolean; onClick?: () => void }) {
+function InsightCard({ label, value, icon, trend, trendUp, onClick, className }: { label: string; value: string | number; icon: string; trend?: string; trendUp?: boolean; onClick?: () => void; className?: string }) {
   return (
     <button
       type="button"
       onClick={onClick}
-      className={`${cardClass} p-5 text-left ${onClick ? 'cursor-pointer hover:border-brand-400 hover:shadow-md' : ''}`}
+      className={`${cardClass} p-5 text-left ${onClick ? 'cursor-pointer hover:border-brand-400 hover:shadow-md' : ''} ${className || ''}`}
     >
       <div className="flex items-center justify-between">
         <div className="h-10 w-10 rounded-lg bg-slate-50 flex items-center justify-center text-slate-600 dark:bg-slate-800 dark:text-slate-300">
@@ -907,7 +907,7 @@ function UsersPage() {
           <InsightCard label="Active" value={stats.active} icon="fa-solid fa-check-circle" />
           <InsightCard label="Disabled" value={stats.disabled} icon="fa-solid fa-ban" />
           <InsightCard label="Expiring Soon" value={stats.expiring} icon="fa-solid fa-clock" trend="Urgent" trendUp={false} />
-          <InsightCard label="High Usage" value={stats.highUsage} icon="fa-solid fa-chart-line" />
+          <InsightCard label="High Usage" value={stats.highUsage} icon="fa-solid fa-chart-line" className="col-span-2 md:col-span-1" />
         </div>
 
         {/* Filters Bar */}


### PR DESCRIPTION
### Motivation
- The Users workspace showed an empty gap on mobile because the High Usage insight occupied only half a row, so the change restores the previous full-width behavior on small screens.

### Description
- Add an optional `className` prop to `InsightCard` in `api/subscription_aggregator/static/web-ui.tsx` to allow per-card layout classes.
- Include the provided `className` when building the card's `className` string so existing behavior remains unchanged when not used.
- Apply `className="col-span-2 md:col-span-1"` to the High Usage insight so it spans both columns on mobile and returns to the original layout on medium+ breakpoints.

### Testing
- Inspected the code changes with `git diff` to confirm the `InsightCard` signature and usage were updated.
- Verified repository status with `git status` to ensure the file was modified.
- Attempted to run the app with `python app.py` for visual confirmation but startup failed due to MySQL pool configuration (`Pool size should be higher than 0 and lower or equal to 32`), so UI render verification could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a1de7ef13c832788af65792383a986)