### PR TITLE
Make High Usage filter full-width on mobile in Users tab

### DIFF
--- a/api/subscription_aggregator/static/web-ui.tsx
+++ b/api/subscription_aggregator/static/web-ui.tsx
@@ -946,11 +946,11 @@ function UsersPage() {
               { id: 'disabled', label: 'Disabled' },
               { id: 'usage', label: 'High Usage' },
               { id: 'expiring', label: 'Expiring' },
-            ].map((f, idx, arr) => (
+            ].map((f) => (
               <button
                 key={f.id}
                 onClick={() => setFilter(f.id as any)}
-                className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${idx === arr.length - 1 ? 'w-full text-center sm:w-auto' : ''} ${
+                className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${f.id === 'usage' ? 'w-full text-center sm:w-auto' : ''} ${
                   filter === f.id
                     ? 'bg-brand-600 text-white dark:bg-brand-500'
                     : 'bg-slate-100 text-slate-600 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-400 dark:hover:bg-slate-700'


### PR DESCRIPTION
### Motivation
- Fix mobile layout so the "High Usage" filter button spans the full row in the Users tab because the previous logic applied full-width to the last filter instead of the High Usage filter; no skills were used.

### Description
- Update `api/subscription_aggregator/static/web-ui.tsx` to apply `w-full text-center sm:w-auto` specifically when `f.id === 'usage'` instead of relying on the button being the last item, and remove the unused `idx`/`arr` parameters from the `.map` callback.

### Testing
- Attempted an automated Playwright screenshot to verify mobile rendering but it failed with `ERR_EMPTY_RESPONSE` because the local web app was not serving, so rendering verification could not be completed; code diff was reviewed to confirm the class logic change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a1df333b1883279b15c62bb70f086c)