### PR TITLE
Add `panel_api_mode` column to panels with sanaei legacy backfill

### DIFF
--- a/services/database.py
+++ b/services/database.py
@@ -135,6 +135,7 @@ def ensure_schema() -> None:
                 access_token VARCHAR(2048) NOT NULL,
                 admin_password_encrypted TEXT NULL,
                 panel_api_version VARCHAR(8) NULL,
+                panel_api_mode VARCHAR(16) NULL,
                 token_refreshed_at DATETIME NULL,
                 template_username VARCHAR(64) NULL,
                 sub_url VARCHAR(2048) NULL,
@@ -174,7 +175,26 @@ def ensure_schema() -> None:
             pass
         try:
             cur.execute(
+                "ALTER TABLE panels ADD COLUMN panel_api_mode VARCHAR(16) NULL AFTER panel_api_version"
+            )
+        except MySQLError:
+            pass
+        try:
+            cur.execute(
                 "ALTER TABLE panels ADD COLUMN token_refreshed_at DATETIME NULL AFTER admin_password_encrypted"
+            )
+        except MySQLError:
+            pass
+        # Keep existing behavior default-safe: any missing mode should behave as legacy (<3).
+        # Only backfill sanaei rows, leaving all other panel types unchanged.
+        try:
+            cur.execute(
+                """
+                UPDATE panels
+                SET panel_api_mode = 'legacy_lt3'
+                WHERE panel_type = 'sanaei'
+                  AND (panel_api_mode IS NULL OR panel_api_mode = '')
+                """
             )
         except MySQLError:
             pass


### PR DESCRIPTION
### Motivation
- Introduce a first-class column to record panel API mode (e.g. `legacy_lt3` / `modern_gt3`) so runtime code can branch on API capabilities without brittle checks. 
- Apply the change as an additive migration to avoid destructive schema changes and preserve existing installations. 
- Ensure existing `panel_type='sanaei'` rows continue to behave as legacy by default so upgrades are safe.

### Description
- Added a nullable `panel_api_mode VARCHAR(16) NULL` to the `panels` `CREATE TABLE` definition and kept it nullable so old behavior remains default-safe. 
- Added an additive migration using `ALTER TABLE panels ADD COLUMN panel_api_mode VARCHAR(16) NULL` wrapped in the existing `try/except` additive-migration pattern. 
- Backfilled existing `panel_type = 'sanaei'` rows with `panel_api_mode = 'legacy_lt3'` only when the column is unset or empty via an `UPDATE` statement, leaving non-sanaei rows untouched. 
- Left runtime selectors unchanged (they already `SELECT *` panel rows), and preserved the implicit fallback that a null/absent mode resolves to legacy `<3` behavior. 

### Testing
- Verified syntax by running `python -m compileall services/database.py` which succeeded. 
- No additional automated unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17ed7d45288330a9222156fe43a8c4)