### PR TITLE
Pass Sanaei panel version into token refresh authenticator

### DIFF
--- a/apis/sanaei.py
+++ b/apis/sanaei.py
@@ -283,12 +283,39 @@ def fetch_subscription_links(sub_url: str) -> List[str]:
         return []
 
 
-def get_admin_token(panel_url: str, username: str, password: str) -> Tuple[Optional[str], Optional[str]]:
+def _is_modern_version(panel_version: str | None) -> bool:
+    text = (panel_version or "").strip()
+    if not text:
+        return False
+    major_text = text.split(".", 1)[0].strip()
+    try:
+        major = int(major_text)
+    except (TypeError, ValueError):
+        return False
+    return major >= 3
+
+
+def get_admin_token(
+    panel_url: str,
+    username: str,
+    password: str,
+    *,
+    panel_version: str | None = None,
+) -> Tuple[Optional[str], Optional[str]]:
     login_url = urljoin(panel_url.rstrip('/') + '/', 'login')
     try:
         resp = SESSION.post(login_url, data={"username": username, "password": password}, timeout=15)
         if resp.status_code != 200:
             return None, f"{resp.status_code} {resp.text[:200]}"
+        if _is_modern_version(panel_version):
+            data = resp.json() if "application/json" in (resp.headers.get("content-type", "").lower()) else {}
+            token = (
+                (data or {}).get("access_token")
+                or (data or {}).get("token")
+                or ((data or {}).get("obj") or {}).get("token")
+            )
+            if token:
+                return f"api_token:{token}", None
         jar = resp.cookies.get_dict()
         cookie_name = None
         cookie_val = None

--- a/services/panel_tokens.py
+++ b/services/panel_tokens.py
@@ -124,8 +124,9 @@ def _panel_refresh_message(panel_id, panel_type: str, panel_url: str, status: st
     )
 
 
-def _authenticator_for_panel_type(panel_type: str):
+def _authenticator_for_panel_type(panel_type: str, panel_row: dict | None = None):
     panel_type = (panel_type or "").lower()
+    panel_row = panel_row or {}
     if panel_type == "marzneshin":
         from apis import marzneshin
 
@@ -141,7 +142,12 @@ def _authenticator_for_panel_type(panel_type: str):
     if panel_type == "sanaei":
         from apis import sanaei
 
-        return sanaei.get_admin_token
+        panel_version = panel_row.get("panel_api_version")
+
+        def _sanaei_auth(panel_url: str, username: str, password: str):
+            return sanaei.get_admin_token(panel_url, username, password, panel_version=panel_version)
+
+        return _sanaei_auth
     return None
 
 
@@ -225,7 +231,7 @@ def ensure_panel_access_token(panel_row: dict, *, force: bool = False, reason: s
     """
 
     panel_type = (panel_row.get("panel_type") or "").lower()
-    auth_fn = _authenticator_for_panel_type(panel_type)
+    auth_fn = _authenticator_for_panel_type(panel_type, panel_row)
     if not auth_fn:
         return panel_row
 
@@ -399,7 +405,7 @@ def refresh_panel_access_token_for_request(panel_url: str, current_token: str, p
             cur.execute(
                 """
                 SELECT id, panel_url, panel_type, access_token, admin_username,
-                       admin_password_encrypted, token_refreshed_at
+                       admin_password_encrypted, panel_api_version, token_refreshed_at
                 FROM panels
                 WHERE panel_url=%s AND panel_type=%s
                 ORDER BY id DESC
@@ -415,7 +421,7 @@ def refresh_panel_access_token_for_request(panel_url: str, current_token: str, p
                 cur.execute(
                     """
                     SELECT id, panel_url, panel_type, access_token, admin_username,
-                           admin_password_encrypted, token_refreshed_at
+                           admin_password_encrypted, panel_api_version, token_refreshed_at
                     FROM panels
                     WHERE panel_url=%s
                     ORDER BY (access_token=%s) DESC, id DESC
@@ -428,7 +434,7 @@ def refresh_panel_access_token_for_request(panel_url: str, current_token: str, p
             cur.execute(
                 """
                 SELECT id, panel_url, panel_type, access_token, admin_username,
-                       admin_password_encrypted, token_refreshed_at
+                       admin_password_encrypted, panel_api_version, token_refreshed_at
                 FROM panels
                 WHERE panel_url=%s
                 ORDER BY (access_token=%s) DESC, id DESC


### PR DESCRIPTION
### Motivation

- Allow Sanaei authenticator to pick the correct auth path (legacy cookie vs modern bearer/api token) using the panel row's API version.
- Ensure auth fallback flows (used during request-time reauth) fetch and propagate `panel_api_version` from the database so Sanaei can resolve the right method.
- Preserve existing refresh behavior for non-Sanaei panels and force legacy behavior for rows with missing/invalid version data.

### Description

- Extend `_authenticator_for_panel_type` signature to accept the full `panel_row` and use `panel_api_version` when constructing the Sanaei auth wrapper, while leaving Marzban/Marzneshin/Rebecca resolvers unchanged.
- Update calls to `_authenticator_for_panel_type` in `ensure_panel_access_token` to pass the `panel_row` so the Sanaei wrapper receives version context via `panel_row.get("panel_api_version")`.
- Add `panel_api_version` to the `SELECT` list in `refresh_panel_access_token_for_request` queries so DB lookups return version information for fallback refreshes.
- Update `apis/sanaei.py` to accept an optional `panel_version` in `get_admin_token`, add helper `_is_modern_version`, and choose modern token extraction (returning `api_token:<token>`) only for version `>= 3`; missing/invalid versions follow the legacy cookie-based path.

### Testing

- Ran `python -m py_compile services/panel_tokens.py apis/sanaei.py` and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17eedb9d348330b2077cbbdc858c2f)