### PR TITLE
Add Sanaei API version quick-select buttons

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -42,7 +42,7 @@ import qrcode
 
 from apis import marzneshin, marzban, rebecca, sanaei, pasarguard, guardcore
 
-from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
+from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup, ReplyKeyboardMarkup
 from telegram.ext import (
     Application, CommandHandler, CallbackQueryHandler, ConversationHandler,
     MessageHandler, ContextTypes, filters,
@@ -3114,9 +3114,14 @@ async def got_panel_type(update: Update, context: ContextTypes.DEFAULT_TYPE):
         return ASK_PANEL_TYPE
     context.user_data["panel_type"] = t
     if t == "sanaei":
+        sanaei_version_kb = ReplyKeyboardMarkup(
+            [["<3", ">3"], ["⬅️ Back"]],
+            resize_keyboard=True,
+            one_time_keyboard=True,
+        )
         await update.message.reply_text(
-            "نسخه API سانایی را مشخص کن: <3 یا >3 (مثال: lt3 / gt3 / 3+)",
-            reply_markup=_back_kb("servers_panels"),
+            "نسخه API سانایی را با دکمه انتخاب کن:",
+            reply_markup=sanaei_version_kb,
         )
         return ASK_PANEL_SANAEI_VERSION
 


### PR DESCRIPTION
### Motivation
- Provide explicit quick-select buttons for Sanaei API version selection to simplify the add-panel flow and reduce free-text input errors.

### Description
- Updated `bot.py` to import `ReplyKeyboardMarkup` and, when `panel_type == "sanaei"`, present a reply keyboard with `"<3"`, `">3"` and a `"⬅️ Back"` button and updated the prompt message while leaving `normalize_sanaei_api_version` logic intact.

### Testing
- Ran `python -m py_compile bot.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17f0a7f2a483309f71961607a7957c)