### PR TITLE
Fix Sanaei legacy/modern login handling and surface clearer bot errors

### DIFF
--- a/apis/sanaei.py
+++ b/apis/sanaei.py
@@ -72,8 +72,8 @@ def _request_with_reauth(
     new_token = refresh_panel_access_token_for_request(panel_url, token, panel_type="sanaei")
     if not new_token:
         return response
-    _, new_raw = _parse_token_auth(new_token)
-    auth_headers = modern_get_headers(new_raw) if auth_mode == "modern" else legacy_get_headers(new_token)
+    new_mode, new_raw = _parse_token_auth(new_token)
+    auth_headers = modern_get_headers(new_raw) if new_mode == "modern" else legacy_get_headers(new_token)
     return SESSION.request(method, url, headers={**auth_headers, **extra_headers}, **kwargs)
 
 
@@ -316,6 +316,8 @@ def get_admin_token(
             )
             if token:
                 return f"api_token:{token}", None
+            body_preview = (resp.text or "")[:200]
+            return None, f"modern login selected but no access token in response (status={resp.status_code}, body={body_preview})"
         jar = resp.cookies.get_dict()
         cookie_name = None
         cookie_val = None

--- a/bot.py
+++ b/bot.py
@@ -3200,9 +3200,19 @@ async def got_panel_pass(update: Update, context: ContextTypes.DEFAULT_TYPE):
     password = (update.message.text or "").strip()
     try:
         api = get_api(panel_type)
-        tok, err = api.get_admin_token(panel_url, panel_user, password)
+        auth_kwargs = {}
+        if panel_type == "sanaei":
+            auth_kwargs["panel_version"] = panel_api_version
+        tok, err = api.get_admin_token(panel_url, panel_user, password, **auth_kwargs)
         if not tok:
-            await update.message.reply_text(f"❌ لاگین ناموفق: {err}")
+            if panel_type == "sanaei":
+                await update.message.reply_text(
+                    f"❌ لاگین ناموفق: {err}\n"
+                    f"🧭 API mode انتخاب‌شده: {panel_api_version or 'نامشخص'}\n"
+                    "اگر پنل شما 3x-ui جدید است، mode را روی >3 بگذار؛ برای نسخه‌های قدیمی <3."
+                )
+            else:
+                await update.message.reply_text(f"❌ لاگین ناموفق: {err}")
             return ConversationHandler.END
         encrypted_password = None
         try:
@@ -3330,15 +3340,23 @@ async def got_edit_panel_pass(update: Update, context: ContextTypes.DEFAULT_TYPE
         placeholders = ",".join(["%s"] * len(ids))
         with with_mysql_cursor() as cur:
             cur.execute(
-                f"SELECT panel_url, panel_type FROM panels WHERE id=%s AND telegram_user_id IN ({placeholders})",
+                f"SELECT panel_url, panel_type, panel_api_version FROM panels WHERE id=%s AND telegram_user_id IN ({placeholders})",
                 tuple([pid] + ids),
             )
             row = cur.fetchone()
         if not row:
             raise RuntimeError("panel not found")
         api = get_api(row.get("panel_type"))
-        tok, err = api.get_admin_token(row["panel_url"], new_user, new_pass)
+        auth_kwargs = {}
+        if row.get("panel_type") == "sanaei":
+            auth_kwargs["panel_version"] = row.get("panel_api_version")
+        tok, err = api.get_admin_token(row["panel_url"], new_user, new_pass, **auth_kwargs)
         if not tok:
+            if row.get("panel_type") == "sanaei":
+                raise RuntimeError(
+                    f"login failed: {err} | API mode={row.get('panel_api_version') or 'unknown'} "
+                    "(new 3x-ui=> >3, old=> <3)"
+                )
             raise RuntimeError(f"login failed: {err}")
         encrypted_password = None
         try:


### PR DESCRIPTION
### Motivation
- Sanaei panel logins started failing after legacy vs modern (3x-ui) token format changes because retried requests kept using the old auth mode instead of the refreshed token's actual mode. 
- When modern (`>3`) mode is selected but the panel returns no JSON token, the bot gave an unhelpful "login failed" message making troubleshooting confusing. 

### Description
- In `apis/sanaei.py` updated `_request_with_reauth` to parse the refreshed token's mode (`legacy` vs `modern`) and use that mode for the retry request by using `new_mode, new_raw = _parse_token_auth(new_token)`. 
- In `apis/sanaei.py` improved `get_admin_token` to return a clear error when modern mode is chosen but no access token is present, including a status and body preview. 
- In `bot.py` changed panel add/edit flows to pass `panel_api_version` into `get_admin_token` for Sanaei panels, added `panel_api_version` to a `SELECT` when updating credentials, and surfaced Sanaei-specific hints to the Telegram user when login fails to help pick `<3` vs `>3`. 

### Testing
- Ran `python -m py_compile apis/sanaei.py bot.py` and the files compiled successfully. 
- No other automated tests were run in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17f275126083308b89df24ee0d079c)