### PR TITLE
Fix 3x-ui login payload handling for admin token fetch

### DIFF
--- a/apis/sanaei.py
+++ b/apis/sanaei.py
@@ -336,7 +336,20 @@ def get_admin_token(
 ) -> Tuple[Optional[str], Optional[str]]:
     login_url = urljoin(panel_url.rstrip('/') + '/', 'login')
     try:
-        resp = SESSION.post(login_url, data={"username": username, "password": password}, timeout=15)
+        # 3x-ui modern API expects JSON payload on /login. Some older deployments
+        # still accept (or only accept) form-encoded data, so we fallback to form
+        # only when JSON login fails with auth/content related status codes.
+        payload = {"username": username, "password": password}
+        resp = SESSION.post(
+            login_url,
+            json=payload,
+            headers={"accept": "application/json"},
+            timeout=15,
+        )
+        if resp.status_code in (400, 401, 403, 415, 422):
+            legacy_resp = SESSION.post(login_url, data=payload, timeout=15)
+            if legacy_resp.status_code == 200:
+                resp = legacy_resp
         if resp.status_code != 200:
             return None, _format_http_error(resp, context="login request failed")
         if _is_modern_version(panel_version):


### PR DESCRIPTION
### Motivation
- Modern 3x-ui panels expect a JSON `POST /login` payload which caused `status=403` failures when the client only sent form-encoded data.
- `get_admin_token` must support both modern JSON-based login and older form-encoded login to be compatible with mixed deployments.

### Description
- Change `get_admin_token` in `apis/sanaei.py` to send a JSON payload (`json=...`) with `Accept: application/json` to `/login` by default.
- Add a compatibility fallback that retries once using form-encoded `data=...` when the JSON login responds with auth/content-related status codes (`400, 401, 403, 415, 422`).
- Preserve existing token and session-cookie extraction logic after a successful login.

### Testing
- Ran `python -m py_compile apis/sanaei.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17f50a61448330b36e396707c84b9a)