### PR TITLE
Add Sanaei panel metadata columns and migrations

### DIFF
--- a/services/database.py
+++ b/services/database.py
@@ -129,6 +129,8 @@ def ensure_schema() -> None:
                 panel_url VARCHAR(255) NOT NULL,
                 name VARCHAR(128) NOT NULL,
                 panel_type VARCHAR(32) NOT NULL DEFAULT 'marzneshin',
+                sanaei_api_version VARCHAR(16) NULL,
+                sanaei_auth_type VARCHAR(16) NULL,
                 usage_multiplier DOUBLE NOT NULL DEFAULT 1.0,
                 append_ratio_to_name TINYINT(1) NOT NULL DEFAULT 0,
                 admin_username VARCHAR(64) NOT NULL,
@@ -147,9 +149,26 @@ def ensure_schema() -> None:
             )
         except MySQLError:
             pass
+        # Sanaei metadata remains nullable so existing rows are not rewritten.
+        # Existing rows with panel_type='sanaei' and sanaei_api_version IS NULL
+        # are treated as legacy. New Sanaei rows should store
+        # sanaei_api_version as 'legacy' or 'modern'; modern rows should store
+        # sanaei_auth_type as 'cookie' (cookieAuth) or 'bearer' (bearerAuth).
         try:
             cur.execute(
-                "ALTER TABLE panels ADD COLUMN usage_multiplier DOUBLE NOT NULL DEFAULT 1.0 AFTER panel_type"
+                "ALTER TABLE panels ADD COLUMN sanaei_api_version VARCHAR(16) NULL AFTER panel_type"
+            )
+        except MySQLError:
+            pass
+        try:
+            cur.execute(
+                "ALTER TABLE panels ADD COLUMN sanaei_auth_type VARCHAR(16) NULL AFTER sanaei_api_version"
+            )
+        except MySQLError:
+            pass
+        try:
+            cur.execute(
+                "ALTER TABLE panels ADD COLUMN usage_multiplier DOUBLE NOT NULL DEFAULT 1.0 AFTER sanaei_auth_type"
             )
         except MySQLError:
             pass


### PR DESCRIPTION
### Motivation
- Provide storage for Sanaei-specific connection metadata without altering existing legacy rows.
- Ensure new metadata can express API version and auth mode so the code can distinguish legacy vs modern Sanaei panels and choose cookie vs bearer auth.

### Description
- Added nullable columns `sanaei_api_version VARCHAR(16) NULL` and `sanaei_auth_type VARCHAR(16) NULL` to the `panels` `CREATE TABLE` schema in `services/database.py`.
- Added guarded `ALTER TABLE panels ADD COLUMN ...` migrations next to the existing `panels` migration block to add `sanaei_api_version` and `sanaei_auth_type` safely on existing databases.
- Documented in-code semantics that rows with `panel_type='sanaei'` and `sanaei_api_version IS NULL` are legacy, that `sanaei_api_version` should be set to `'legacy'` or `'modern'`, and that modern rows should set `sanaei_auth_type` to `'cookie'` or `'bearer'` to match `cookieAuth` / `bearerAuth` in `docs/sanaei-new-version.json`.
- No other application logic or existing columns were changed to preserve backward compatibility with legacy rows.

### Testing
- Ran `python -m py_compile services/database.py` which succeeded.
- Ran `git diff --check` to validate whitespace/errors which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ef57501a48330b02853cf47321484)