### PR TITLE
Dispatch modern Sanaei adapter by panel metadata

### DIFF
--- a/api/subscription_aggregator/flask_app.py
+++ b/api/subscription_aggregator/flask_app.py
@@ -29,7 +29,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from services import ensure_panel_tokens, init_mysql_pool, with_mysql_cursor
 from services.database import errorcode, mysql_errors
 from services.settings import get_setting as get_owner_setting
-from apis import sanaei, pasarguard, rebecca, guardcore
+from apis import sanaei, sanaei_modern, pasarguard, rebecca, guardcore
 from .ownership import expand_owner_ids, canonical_owner_id
 
 logging.basicConfig(
@@ -67,6 +67,11 @@ _fetch_links_cache = TTLCache(maxsize=256, ttl=FETCH_CACHE_TTL)
 _fetch_links_lock = RLock()
 
 _settings_table_missing_logged = False
+
+def get_sanaei_api(sanaei_api_version: str | None = None):
+    if (sanaei_api_version or "").lower() == "modern":
+        return sanaei_modern
+    return sanaei
 
 
 def get_setting(owner_id: int, key: str):
@@ -122,6 +127,7 @@ def list_mapped_links(owner_id, local_username):
             f"""
             SELECT lup.panel_id, lup.remote_username,
                    p.panel_url, p.access_token, p.panel_type,
+                   p.sanaei_api_version,
                    p.admin_username, p.admin_password_encrypted,
                    p.usage_multiplier, p.append_ratio_to_name
             FROM local_user_panel_links lup
@@ -146,6 +152,7 @@ def list_all_panels(owner_id):
         cur.execute(
             f"""
             SELECT id, panel_url, access_token, panel_type,
+                   sanaei_api_version,
                    admin_username, admin_password_encrypted,
                    usage_multiplier, append_ratio_to_name
             FROM panels
@@ -216,13 +223,14 @@ def send_owner_limit_notification(owner_id: int, message: str):
         log.warning("failed sending limit event notification to %s: %s", owner_id, exc)
 
 
-def disable_remote(panel_type, panel_url, token, remote_username):
+def disable_remote(panel_type, panel_url, token, remote_username, sanaei_api_version=None):
     try:
         if panel_type == "sanaei":
+            api = get_sanaei_api(sanaei_api_version)
             remotes = [r.strip() for r in remote_username.split(",") if r.strip()]
             all_ok, last_msg = True, None
             for rn in remotes:
-                ok, msg = sanaei.disable_remote_user(panel_url, token, rn)
+                ok, msg = api.disable_remote_user(panel_url, token, rn)
                 if not ok:
                     all_ok = False
                     last_msg = msg
@@ -377,15 +385,16 @@ def collect_links(mapped, local_username: str, want_html: bool):
         disabled_nums = di_map.get(l["panel_id"], set())
         links, errs, rinfo = [], [], None
         if l.get("panel_type") == "sanaei":
+            api = get_sanaei_api(l.get("sanaei_api_version"))
             remotes = [r.strip() for r in l["remote_username"].split(",") if r.strip()]
 
             def remote_worker(rn: str):
                 info = None
                 if want_html:
-                    u, uerr = sanaei.get_user(l["panel_url"], l["access_token"], rn)
+                    u, uerr = api.get_user(l["panel_url"], l["access_token"], rn)
                     if not uerr:
                         info = u
-                ls, err = sanaei.fetch_links_from_panel(l["panel_url"], l["access_token"], rn)
+                ls, err = api.fetch_links_from_panel(l["panel_url"], l["access_token"], rn)
                 if err:
                     err = f"{rn}@{l['panel_url']}: {err}"
                 return ls, err, info
@@ -637,7 +646,8 @@ def list_all_agent_links(owner_id: int):
     with with_mysql_cursor() as cur:
         cur.execute(
             f"""
-            SELECT lup.local_username, lup.remote_username, p.panel_url, p.access_token, p.panel_type
+            SELECT lup.local_username, lup.remote_username, p.panel_url, p.access_token, p.panel_type,
+                   p.sanaei_api_version
             FROM local_user_panel_links lup
             JOIN panels p ON p.id = lup.panel_id
             WHERE lup.owner_id IN ({placeholders})
@@ -934,7 +944,7 @@ def unified_links(local_username, app_key):
             agent_blocked = True
             if not pushed_a:
                 for l in list_all_agent_links(owner_id):
-                    code, msg = disable_remote(l["panel_type"], l["panel_url"], l["access_token"], l["remote_username"])
+                    code, msg = disable_remote(l["panel_type"], l["panel_url"], l["access_token"], l["remote_username"], l.get("sanaei_api_version"))
                     if code and code != 200:
                         log.warning("AGENT disable on %s@%s -> %s %s",
                                     l["remote_username"], l["panel_url"], code, msg)
@@ -959,10 +969,11 @@ def unified_links(local_username, app_key):
                 panels = list_all_panels(owner_id)
                 links = [{"panel_id": p["id"], "remote_username": local_username,
                           "panel_url": p["panel_url"], "access_token": p["access_token"],
-                          "panel_type": p["panel_type"]} for p in panels]
+                          "panel_type": p["panel_type"],
+                          "sanaei_api_version": p.get("sanaei_api_version")} for p in panels]
             for l in links:
                 code, msg = disable_remote(
-                    l["panel_type"], l["panel_url"], l["access_token"], l["remote_username"]
+                    l["panel_type"], l["panel_url"], l["access_token"], l["remote_username"], l.get("sanaei_api_version")
                 )
                 if code and code != 200:
                     log.warning("disable on %s@%s -> %s %s", l["remote_username"], l["panel_url"], code, msg)
@@ -986,9 +997,10 @@ def unified_links(local_username, app_key):
                     panels = list_all_panels(owner_id)
                     links = [{"panel_id": p["id"], "remote_username": local_username,
                               "panel_url": p["panel_url"], "access_token": p["access_token"],
-                              "panel_type": p["panel_type"]} for p in panels]
+                              "panel_type": p["panel_type"],
+                          "sanaei_api_version": p.get("sanaei_api_version")} for p in panels]
                 for l in links:
-                    code, msg = disable_remote(l["panel_type"], l["panel_url"], l["access_token"], l["remote_username"])
+                    code, msg = disable_remote(l["panel_type"], l["panel_url"], l["access_token"], l["remote_username"], l.get("sanaei_api_version"))
                     if code and code != 200:
                         log.warning("disable on %s@%s -> %s %s", l["remote_username"], l["panel_url"], code, msg)
                 mark_user_disabled(owner_id, local_username)
@@ -1011,9 +1023,10 @@ def unified_links(local_username, app_key):
                     panels = list_all_panels(owner_id)
                     links = [{"panel_id": p["id"], "remote_username": local_username,
                               "panel_url": p["panel_url"], "access_token": p["access_token"],
-                              "panel_type": p["panel_type"]} for p in panels]
+                              "panel_type": p["panel_type"],
+                          "sanaei_api_version": p.get("sanaei_api_version")} for p in panels]
                 for l in links:
-                    code, msg = disable_remote(l["panel_type"], l["panel_url"], l["access_token"], l["remote_username"])
+                    code, msg = disable_remote(l["panel_type"], l["panel_url"], l["access_token"], l["remote_username"], l.get("sanaei_api_version"))
                     if code and code != 200:
                         log.warning("disable on %s@%s -> %s %s", l["remote_username"], l["panel_url"], code, msg)
                 mark_user_disabled(owner_id, local_username)
@@ -1053,6 +1066,7 @@ def unified_links(local_username, app_key):
                     "panel_url": p["panel_url"],
                     "access_token": p["access_token"],
                     "panel_type": p["panel_type"],
+                    "sanaei_api_version": p.get("sanaei_api_version"),
                 }
                 for p in panels
             ]

--- a/bot.py
+++ b/bot.py
@@ -40,7 +40,7 @@ from dotenv import load_dotenv
 from mysql.connector import Error as MySQLError
 import qrcode
 
-from apis import marzneshin, marzban, rebecca, sanaei, pasarguard, guardcore
+from apis import marzneshin, marzban, rebecca, sanaei, sanaei_modern, pasarguard, guardcore
 
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import (
@@ -94,8 +94,11 @@ API_MODULES = {
     "guardcore": guardcore,
 }
 
-def get_api(panel_type: str):
-    return API_MODULES.get(panel_type or "marzneshin", marzneshin)
+def get_api(panel_type: str, sanaei_api_version: str | None = None):
+    panel_type = (panel_type or "marzneshin").lower()
+    if panel_type == "sanaei" and (sanaei_api_version or "").lower() == "modern":
+        return sanaei_modern
+    return API_MODULES.get(panel_type, marzneshin)
 
 
 def panel_username(panel_type: str, username: str) -> str:
@@ -862,7 +865,7 @@ def update_limit(owner_id: int, username: str, new_limit_bytes: int):
                 tuple(ids) + (username,),
             )
     for row in list_user_links(owner_id, username):
-        api = get_api(row.get("panel_type"))
+        api = get_api(row.get("panel_type"), row.get("sanaei_api_version"))
         remotes = (
             row["remote_username"].split(",")
             if row.get("panel_type") == "sanaei"
@@ -928,7 +931,7 @@ def set_user_disabled(owner_id: int, username: str, disabled: bool):
         )
 
     for row in list_user_links(owner_id, username):
-        api = get_api(row.get("panel_type"))
+        api = get_api(row.get("panel_type"), row.get("sanaei_api_version"))
         remotes = (
             row["remote_username"].split(",")
             if row.get("panel_type") == "sanaei"
@@ -972,7 +975,7 @@ def reset_used(owner_id: int, username: str):
             params,
         )
     for row in list_user_links(owner_id, username):
-        api = get_api(row.get("panel_type"))
+        api = get_api(row.get("panel_type"), row.get("sanaei_api_version"))
         remotes = (
             row["remote_username"].split(",")
             if row.get("panel_type") == "sanaei"
@@ -1025,7 +1028,7 @@ def renew_user(owner_id: int, username: str, add_days: int):
                 tuple(ids) + (username,),
             )
     for r in list_user_links(owner_id, username):
-        api = get_api(r.get("panel_type"))
+        api = get_api(r.get("panel_type"), r.get("sanaei_api_version"))
         remotes = (
             r["remote_username"].split(",")
             if r.get("panel_type") == "sanaei"
@@ -1052,6 +1055,7 @@ def list_user_links(owner_id: int, local_username: str):
         cur.execute(
             f"""SELECT lup.panel_id, lup.remote_username,
                       p.panel_url, p.access_token, p.panel_type,
+                      p.sanaei_api_version,
                       p.admin_username, p.admin_password_encrypted
                  FROM local_user_panel_links lup
                  JOIN panels p ON p.id = lup.panel_id
@@ -1090,7 +1094,7 @@ def delete_user(owner_id: int, username: str):
     rows = list_user_links(owner_id, username)
     for r in rows:
         try:
-            api = get_api(r.get("panel_type"))
+            api = get_api(r.get("panel_type"), r.get("sanaei_api_version"))
             remotes = (
                 r["remote_username"].split(",")
                 if r.get("panel_type") == "sanaei"
@@ -1226,7 +1230,8 @@ def list_panel_links(panel_id: int):
     with with_mysql_cursor() as cur:
         cur.execute("""
             SELECT lup.owner_id, lup.local_username, lup.remote_username,
-                   p.panel_url, p.access_token, p.panel_type
+                   p.panel_url, p.access_token, p.panel_type,
+                   p.sanaei_api_version
             FROM local_user_panel_links lup
             JOIN panels p ON p.id = lup.panel_id
             WHERE lup.panel_id=%s
@@ -1238,7 +1243,7 @@ def delete_panel_and_cleanup(owner_id: int, panel_id: int):
     rows = list_panel_links(panel_id)
     for r in rows:
         try:
-            api = get_api(r.get("panel_type"))
+            api = get_api(r.get("panel_type"), r.get("sanaei_api_version"))
             remotes = (
                 r["remote_username"].split(",")
                 if r.get("panel_type") == "sanaei"
@@ -2416,7 +2421,7 @@ async def show_panel_cfg_selector(q, context: ContextTypes.DEFAULT_TYPE, owner_i
         await q.edit_message_text("پنل پیدا نشد.")
         return ConversationHandler.END
 
-    api = get_api(info.get("panel_type"))
+    api = get_api(info.get("panel_type"), info.get("sanaei_api_version"))
     links = []
     if info.get("template_username"):
         u, e = api.get_user(info["panel_url"], info["access_token"], info["template_username"])
@@ -2455,7 +2460,7 @@ async def show_panel_cfgnum_selector(q, context: ContextTypes.DEFAULT_TYPE, owne
         await q.edit_message_text("پنل پیدا نشد.")
         return ConversationHandler.END
 
-    api = get_api(info.get("panel_type"))
+    api = get_api(info.get("panel_type"), info.get("sanaei_api_version"))
     links = []
     if info.get("template_username"):
         u, e = api.get_user(info["panel_url"], info["access_token"], info["template_username"])
@@ -3172,7 +3177,7 @@ async def got_panel_pass(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 await update.message.reply_text("❌ API token خالیه.", reply_markup=_back_kb("servers_panels"))
                 return ConversationHandler.END
         else:
-            api = get_api(panel_type)
+            api = get_api(panel_type, sanaei_api_version)
             tok, err = api.get_admin_token(panel_url, panel_user, password)
             if not tok:
                 await update.message.reply_text(f"❌ لاگین ناموفق: {err}")
@@ -3313,13 +3318,13 @@ async def got_edit_panel_pass(update: Update, context: ContextTypes.DEFAULT_TYPE
         placeholders = ",".join(["%s"] * len(ids))
         with with_mysql_cursor() as cur:
             cur.execute(
-                f"SELECT panel_url, panel_type FROM panels WHERE id=%s AND telegram_user_id IN ({placeholders})",
+                f"SELECT panel_url, panel_type, sanaei_api_version FROM panels WHERE id=%s AND telegram_user_id IN ({placeholders})",
                 tuple([pid] + ids),
             )
             row = cur.fetchone()
         if not row:
             raise RuntimeError("panel not found")
-        api = get_api(row.get("panel_type"))
+        api = get_api(row.get("panel_type"), row.get("sanaei_api_version"))
         tok, err = api.get_admin_token(row["panel_url"], new_user, new_pass)
         if not tok:
             raise RuntimeError(f"login failed: {err}")
@@ -3657,7 +3662,7 @@ async def finalize_create_on_selected(q, context, owner_id: int, selected_ids: s
 
     per_panel, errs = {}, []
     for r in rows:
-        api = get_api(r.get("panel_type"))
+        api = get_api(r.get("panel_type"), r.get("sanaei_api_version"))
         if r.get("panel_type") in ("marzneshin", "guardcore"):
             svc, e = api.fetch_user_services(
                 r["panel_url"], r["access_token"], r.get("template_username")
@@ -3704,7 +3709,7 @@ async def finalize_create_on_selected(q, context, owner_id: int, selected_ids: s
     ok, failed = 0, []
     created_remotes: list[tuple[dict, list[str]]] = []
     for r in rows:
-        api = get_api(r.get("panel_type"))
+        api = get_api(r.get("panel_type"), r.get("sanaei_api_version"))
         remote_name = panel_username(r.get("panel_type"), app_username)
         if r.get("panel_type") == "marzneshin":
             payload = {
@@ -3804,7 +3809,7 @@ async def finalize_create_on_selected(q, context, owner_id: int, selected_ids: s
 
     if failed:
         for panel, remote_names in created_remotes:
-            api = get_api(panel.get("panel_type"))
+            api = get_api(panel.get("panel_type"), panel.get("sanaei_api_version"))
             for remote in remote_names:
                 ok_rm, err_rm = api.remove_remote_user(panel["panel_url"], panel["access_token"], remote)
                 if not ok_rm:
@@ -3853,7 +3858,7 @@ def sync_user_panels(owner_id: int, username: str, selected_ids: set):
                 panel = panels_map.get(int(pid))
                 if not panel:
                     continue
-                api = get_api(panel.get("panel_type"))
+                api = get_api(panel.get("panel_type"), panel.get("sanaei_api_version"))
                 remotes = (
                     remote.split(",")
                     if panel.get("panel_type") == "sanaei"
@@ -3912,7 +3917,7 @@ def sync_user_panels(owner_id: int, username: str, selected_ids: set):
             p = panels_map.get(int(pid))
             if not p:
                 continue
-            api = get_api(p.get("panel_type"))
+            api = get_api(p.get("panel_type"), p.get("sanaei_api_version"))
             tmpl = p.get("template_username")
             if p.get("panel_type") == "marzneshin":
                 if not tmpl:
@@ -4123,7 +4128,7 @@ def sync_user_panels(owner_id: int, username: str, selected_ids: set):
             links_map.pop(int(pid), None)
             removed += 1
             if p:
-                api = get_api(p.get("panel_type"))
+                api = get_api(p.get("panel_type"), p.get("sanaei_api_version"))
                 remotes = remote.split(",") if p.get("panel_type") == "sanaei" else [remote]
                 for rn in remotes:
                     log.info(
@@ -4159,7 +4164,7 @@ def sync_user_panels(owner_id: int, username: str, selected_ids: set):
         p = panels_map.get(int(pid))
         if not p:
             continue
-        api = get_api(p.get("panel_type"))
+        api = get_api(p.get("panel_type"), p.get("sanaei_api_version"))
         remote = links_map.get(int(pid), panel_username(p.get("panel_type"), username))
         remotes = remote.split(",") if p.get("panel_type") == "sanaei" else [remote]
         for rn in remotes:

--- a/scripts/usage_sync.py
+++ b/scripts/usage_sync.py
@@ -14,7 +14,7 @@ from services.database import mysql_errors
 from services.panel_tokens import ensure_panel_tokens
 from services.settings import get_setting as get_owner_setting
 
-from apis import marzneshin, marzban, rebecca, sanaei, pasarguard, guardcore
+from apis import marzneshin, marzban, rebecca, sanaei, sanaei_modern, pasarguard, guardcore
 
 logging.basicConfig(
     format="%(asctime)s | %(levelname)s | usage_sync | %(message)s",
@@ -44,9 +44,12 @@ AGENT_INTERVAL_SETTING_KEYS = {
 }
 
 
-def get_api(panel_type: str):
-    """Return API module for the given panel type."""
-    return API_MODULES.get(panel_type or "marzneshin", marzneshin)
+def get_api(panel_type: str, sanaei_api_version: str | None = None):
+    """Return API module for the given panel type and Sanaei API generation."""
+    panel_type = (panel_type or "marzneshin").lower()
+    if panel_type == "sanaei" and (sanaei_api_version or "").lower() == "modern":
+        return sanaei_modern
+    return API_MODULES.get(panel_type, marzneshin)
 
 # ---------------- existing per-link / per-user logic ----------------
 
@@ -133,6 +136,7 @@ def fetch_all_links():
                        p.panel_url,
                        p.access_token,
                        p.panel_type,
+                       p.sanaei_api_version,
                        p.usage_multiplier,
                        p.admin_username,
                        p.admin_password_encrypted,
@@ -165,10 +169,10 @@ def fetch_all_links():
             return []
         raise
 
-def fetch_used_traffic(panel_type, panel_url, bearer, remote_username):
+def fetch_used_traffic(panel_type, panel_url, bearer, remote_username, sanaei_api_version=None):
     """Return used traffic for a remote user via appropriate panel API."""
     try:
-        api = get_api(panel_type)
+        api = get_api(panel_type, sanaei_api_version)
         if panel_type == "sanaei" and "," in remote_username:
             total = 0
             for rn in [r.strip() for r in remote_username.split(",") if r.strip()]:
@@ -561,7 +565,8 @@ def send_nightly_panel_usage_report_if_due(now_utc: datetime, last_sent_local_da
 def list_links_of_local_user(owner_id, local_username):
     with with_mysql_cursor() as cur:
         cur.execute("""
-            SELECT lup.panel_id, lup.remote_username, p.panel_url, p.access_token, p.panel_type
+            SELECT lup.panel_id, lup.remote_username, p.panel_url, p.access_token, p.panel_type,
+                   p.sanaei_api_version
             FROM local_user_panel_links lup
             JOIN panels p ON p.id = lup.panel_id
             WHERE lup.owner_id=%s AND lup.local_username=%s
@@ -576,8 +581,8 @@ def mark_user_disabled(owner_id, local_username):
             WHERE owner_id=%s AND username=%s
         """, (owner_id, local_username))
 
-def disable_remote(panel_type, panel_url, token, remote_username):
-    api = get_api(panel_type)
+def disable_remote(panel_type, panel_url, token, remote_username, sanaei_api_version=None):
+    api = get_api(panel_type, sanaei_api_version)
     remotes = remote_username.split(",") if panel_type == "sanaei" else [remote_username]
     all_ok, last_msg = True, None
     for rn in remotes:
@@ -588,8 +593,8 @@ def disable_remote(panel_type, panel_url, token, remote_username):
     return (200 if all_ok else None), last_msg
 
 
-def enable_remote(panel_type, panel_url, token, remote_username):
-    api = get_api(panel_type)
+def enable_remote(panel_type, panel_url, token, remote_username, sanaei_api_version=None):
+    api = get_api(panel_type, sanaei_api_version)
     remotes = remote_username.split(",") if panel_type == "sanaei" else [remote_username]
     all_ok, last_msg = True, None
     for rn in remotes:
@@ -630,7 +635,7 @@ def try_disable_if_user_exceeded(owner_id, local_username):
         if not pushed:
             links = list_links_of_local_user(owner_id, local_username)
             for l in links:
-                code, msg = disable_remote(l["panel_type"], l["panel_url"], l["access_token"], l["remote_username"])
+                code, msg = disable_remote(l["panel_type"], l["panel_url"], l["access_token"], l["remote_username"], l.get("sanaei_api_version"))
                 if code and code != 200:
                     log.warning("disable on %s@%s -> %s %s", l["remote_username"], l["panel_url"], code, msg)
                 else:
@@ -651,7 +656,7 @@ def try_enable_if_user_ok(owner_id, local_username):
     if pushed and (limit == 0 or used < limit):
         links = list_links_of_local_user(owner_id, local_username)
         for l in links:
-            code, msg = enable_remote(l["panel_type"], l["panel_url"], l["access_token"], l["remote_username"])
+            code, msg = enable_remote(l["panel_type"], l["panel_url"], l["access_token"], l["remote_username"], l.get("sanaei_api_version"))
             if code and code != 200:
                 log.warning("enable on %s@%s -> %s %s", l["remote_username"], l["panel_url"], code, msg)
             else:
@@ -698,7 +703,7 @@ def list_agent_assigned_panels(owner_id: int):
     """پنل‌هایی که به نماینده assign شده‌اند (agent_panels)."""
     with with_mysql_cursor() as cur:
         cur.execute("""
-            SELECT p.id, p.panel_url, p.access_token, p.panel_type
+            SELECT p.id, p.panel_url, p.access_token, p.panel_type, p.sanaei_api_version
             FROM agent_panels ap
             JOIN panels p ON p.id = ap.panel_id
             WHERE ap.agent_tg_id=%s
@@ -725,7 +730,7 @@ def disable_user_on_assigned_panels(owner_id: int, username: str):
     """اگر مپ مستقیمی نبود، روی پنل‌های assign‌شده هم با همان username دیزیبل کن."""
     panels = list_agent_assigned_panels(owner_id)
     for p in panels:
-        code, msg = disable_remote(p["panel_type"], p["panel_url"], p["access_token"], username)
+        code, msg = disable_remote(p["panel_type"], p["panel_url"], p["access_token"], username, p.get("sanaei_api_version"))
         if code and code != 200:
             log.warning("disable (assigned) on %s@%s -> %s %s", username, p["panel_url"], code, msg)
         else:
@@ -735,7 +740,7 @@ def enable_user_on_assigned_panels(owner_id: int, username: str):
     """اگر مپ مستقیمی نبود، روی پنل‌های assign‌شده هم با همان username فعال کن."""
     panels = list_agent_assigned_panels(owner_id)
     for p in panels:
-        code, msg = enable_remote(p["panel_type"], p["panel_url"], p["access_token"], username)
+        code, msg = enable_remote(p["panel_type"], p["panel_url"], p["access_token"], username, p.get("sanaei_api_version"))
         if code and code != 200:
             log.warning("enable (assigned) on %s@%s -> %s %s", username, p["panel_url"], code, msg)
         else:
@@ -810,7 +815,7 @@ def try_disable_agent_if_exceeded(owner_id: int):
             # 1) disable روی مپ‌های مستقیم کاربر
             links = list_links_of_local_user(owner_id, uname)
             for l in links:
-                code, msg = disable_remote(l["panel_type"], l["panel_url"], l["access_token"], l["remote_username"])
+                code, msg = disable_remote(l["panel_type"], l["panel_url"], l["access_token"], l["remote_username"], l.get("sanaei_api_version"))
                 if code and code != 200:
                     log.warning("[AGENT] disable on %s@%s -> %s %s", l["remote_username"], l["panel_url"], code, msg)
                 else:
@@ -856,7 +861,7 @@ def try_enable_agent_if_ok(owner_id: int):
                 continue
             links = list_links_of_local_user(owner_id, uname)
             for l in links:
-                code, msg = enable_remote(l["panel_type"], l["panel_url"], l["access_token"], l["remote_username"])
+                code, msg = enable_remote(l["panel_type"], l["panel_url"], l["access_token"], l["remote_username"], l.get("sanaei_api_version"))
                 if code and code != 200:
                     log.warning("[AGENT] enable on %s@%s -> %s %s", l["remote_username"], l["panel_url"], code, msg)
                 else:
@@ -902,7 +907,7 @@ def loop():
 
                 user_failed = False
                 for row in user_links:
-                    used, err = fetch_used_traffic(row["panel_type"], row["panel_url"], row["access_token"], row["remote_username"])
+                    used, err = fetch_used_traffic(row["panel_type"], row["panel_url"], row["access_token"], row["remote_username"], row.get("sanaei_api_version"))
                     if used is None:
                         log.warning("fetch_used_traffic failed for %s@%s: %s",
                                     row["remote_username"], row["panel_url"], err)


### PR DESCRIPTION
### Motivation
- Route Sanaei API calls to the new modern adapter for panels that opt into the newer API while preserving the legacy `apis.sanaei` behavior for existing panels. 
- Make panel-level Sanaei API generation explicit so API call sites can choose the correct adapter without changing how callers interact with panel APIs. 

### Description
- Imported the modern adapter (`sanaei_modern`) alongside the legacy adapter in `bot.py`, `scripts/usage_sync.py`, and `api/subscription_aggregator/flask_app.py`. 
- Replaced `get_api(panel_type)` with `get_api(panel_type, sanaei_api_version=None)` and dispatch to `sanaei_modern` only when `panel_type == "sanaei"` and `sanaei_api_version == "modern"`, otherwise return the legacy adapter. 
- Propagated `sanaei_api_version` through call sites and helper functions by: adding `p.sanaei_api_version` to relevant `SELECT` queries, returning it with panel rows, and passing it into `get_api` and `disable/enable/fetch` helpers (examples: `fetch_used_traffic`, `disable_remote`, `enable_remote`). 
- Added `get_sanaei_api` helper in the subscription aggregator to choose the correct Sanaei adapter and updated Sanaei-specific code paths (multiple-remote handling, link fetching, disable/enable flows) to call the chosen adapter. 

### Testing
- Ran syntax checks with `python -m py_compile bot.py scripts/usage_sync.py api/subscription_aggregator/flask_app.py`, which completed successfully. 
- Ran repository static check `git diff --check` with no issues reported. 
- Verified updated code paths compile and that `sanaei_api_version` is selected and forwarded in all modified query and API call sites.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ef99e62d483309e8e4331fc7af974)