### PR TITLE
Fix Sanaei token refresh auth strategy

### DIFF
--- a/api/subscription_aggregator/flask_app.py
+++ b/api/subscription_aggregator/flask_app.py
@@ -127,7 +127,7 @@ def list_mapped_links(owner_id, local_username):
             f"""
             SELECT lup.panel_id, lup.remote_username,
                    p.panel_url, p.access_token, p.panel_type,
-                   p.sanaei_api_version,
+                   p.sanaei_api_version, p.sanaei_auth_type,
                    p.admin_username, p.admin_password_encrypted,
                    p.usage_multiplier, p.append_ratio_to_name
             FROM local_user_panel_links lup
@@ -152,7 +152,7 @@ def list_all_panels(owner_id):
         cur.execute(
             f"""
             SELECT id, panel_url, access_token, panel_type,
-                   sanaei_api_version,
+                   sanaei_api_version, sanaei_auth_type,
                    admin_username, admin_password_encrypted,
                    usage_multiplier, append_ratio_to_name
             FROM panels

--- a/bot.py
+++ b/bot.py
@@ -1055,7 +1055,7 @@ def list_user_links(owner_id: int, local_username: str):
         cur.execute(
             f"""SELECT lup.panel_id, lup.remote_username,
                       p.panel_url, p.access_token, p.panel_type,
-                      p.sanaei_api_version,
+                      p.sanaei_api_version, p.sanaei_auth_type,
                       p.admin_username, p.admin_password_encrypted
                  FROM local_user_panel_links lup
                  JOIN panels p ON p.id = lup.panel_id

--- a/scripts/usage_sync.py
+++ b/scripts/usage_sync.py
@@ -137,6 +137,7 @@ def fetch_all_links():
                        p.access_token,
                        p.panel_type,
                        p.sanaei_api_version,
+                       p.sanaei_auth_type,
                        p.usage_multiplier,
                        p.admin_username,
                        p.admin_password_encrypted,

--- a/services/panel_tokens.py
+++ b/services/panel_tokens.py
@@ -124,8 +124,29 @@ def _panel_refresh_message(panel_id, panel_type: str, panel_url: str, status: st
     )
 
 
-def _authenticator_for_panel_type(panel_type: str):
-    panel_type = (panel_type or "").lower()
+def _normalise_sanaei_api_version(panel_row: dict) -> str:
+    return (panel_row.get("sanaei_api_version") or "legacy").strip().lower()
+
+
+def _normalise_sanaei_auth_type(panel_row: dict) -> str:
+    raw = (panel_row.get("sanaei_auth_type") or "").strip().lower()
+    if raw in {"bearer", "bearerauth", "api_key", "apikey", "token"}:
+        return "bearer"
+    if raw in {"cookie", "cookieauth", "session"}:
+        return "cookie"
+    return raw
+
+
+def _sanaei_bearer_refresh_unsupported(panel_row: dict) -> bool:
+    return (
+        (panel_row.get("panel_type") or "").lower() == "sanaei"
+        and _normalise_sanaei_api_version(panel_row) == "modern"
+        and _normalise_sanaei_auth_type(panel_row) == "bearer"
+    )
+
+
+def _authenticator_for_panel_type(panel_row: dict):
+    panel_type = (panel_row.get("panel_type") or "").lower()
     if panel_type == "marzneshin":
         from apis import marzneshin
 
@@ -139,6 +160,13 @@ def _authenticator_for_panel_type(panel_type: str):
 
         return rebecca.get_admin_token
     if panel_type == "sanaei":
+        if _normalise_sanaei_api_version(panel_row) == "modern":
+            if _normalise_sanaei_auth_type(panel_row) == "bearer":
+                return None
+            from apis import sanaei_modern
+
+            return sanaei_modern.get_admin_token
+
         from apis import sanaei
 
         return sanaei.get_admin_token
@@ -225,11 +253,11 @@ def ensure_panel_access_token(panel_row: dict, *, force: bool = False, reason: s
     """
 
     panel_type = (panel_row.get("panel_type") or "").lower()
-    auth_fn = _authenticator_for_panel_type(panel_type)
-    if not auth_fn:
+    auth_fn = _authenticator_for_panel_type(panel_row)
+    bearer_refresh_unsupported = _sanaei_bearer_refresh_unsupported(panel_row)
+    if not auth_fn and not bearer_refresh_unsupported:
         return panel_row
 
-    token = panel_row.get("access_token") or ""
     panel_key = _panel_cache_key(panel_row)
     lock = _panel_singleflight_lock(panel_key)
 
@@ -250,6 +278,18 @@ def ensure_panel_access_token(panel_row: dict, *, force: bool = False, reason: s
             hourly_due = not last_hourly or (now - last_hourly) >= HOURLY_CREDENTIAL_CHECK_INTERVAL
             if not hourly_due:
                 return panel_row
+
+        if not auth_fn:
+            log.info(
+                "Skipping Sanaei bearer token refresh panel_key=%s reason=%s: bearer tokens are not username/password refreshable",
+                panel_key,
+                reason,
+            )
+            if force:
+                _last_auth_fallback_check_at[panel_key] = now
+            else:
+                _last_credential_check_at[panel_key] = now
+            return panel_row
 
         log.info(
             "Running panel credential check panel_key=%s force=%s reason=%s",
@@ -398,8 +438,9 @@ def refresh_panel_access_token_for_request(panel_url: str, current_token: str, p
         if panel_type:
             cur.execute(
                 """
-                SELECT id, panel_url, panel_type, access_token, admin_username,
-                       admin_password_encrypted, token_refreshed_at
+                SELECT id, panel_url, panel_type, sanaei_api_version, sanaei_auth_type,
+                       access_token, admin_username, admin_password_encrypted,
+                       token_refreshed_at
                 FROM panels
                 WHERE panel_url=%s AND panel_type=%s
                 ORDER BY id DESC
@@ -414,8 +455,9 @@ def refresh_panel_access_token_for_request(panel_url: str, current_token: str, p
                 # Fallback to URL lookup so auth-refresh still works.
                 cur.execute(
                     """
-                    SELECT id, panel_url, panel_type, access_token, admin_username,
-                           admin_password_encrypted, token_refreshed_at
+                    SELECT id, panel_url, panel_type, sanaei_api_version, sanaei_auth_type,
+                           access_token, admin_username, admin_password_encrypted,
+                           token_refreshed_at
                     FROM panels
                     WHERE panel_url=%s
                     ORDER BY (access_token=%s) DESC, id DESC
@@ -427,8 +469,9 @@ def refresh_panel_access_token_for_request(panel_url: str, current_token: str, p
         else:
             cur.execute(
                 """
-                SELECT id, panel_url, panel_type, access_token, admin_username,
-                       admin_password_encrypted, token_refreshed_at
+                SELECT id, panel_url, panel_type, sanaei_api_version, sanaei_auth_type,
+                       access_token, admin_username, admin_password_encrypted,
+                       token_refreshed_at
                 FROM panels
                 WHERE panel_url=%s
                 ORDER BY (access_token=%s) DESC, id DESC


### PR DESCRIPTION
### Motivation
- Ensure token refresh uses the correct Sanaei authentication strategy (legacy vs modern) and that modern bearer tokens are not overwritten by cookie-based username/password refresh attempts.
- Include Sanaei metadata in rows used for refresh so decision logic can access `sanaei_api_version` and `sanaei_auth_type`.
- Avoid triggering username/password refresh for modern Sanaei panels configured with a stored bearer token which is not refreshable by login.

### Description
- Updated `services/panel_tokens.py` to accept the full panel row in the authenticator path and added helpers ` _normalise_sanaei_api_version`, `_normalise_sanaei_auth_type`, and `_sanaei_bearer_refresh_unsupported` to classify Sanaei strategies.
- Changed `_authenticator_for_panel_type` to take a `panel_row` dict and route Sanaei panels to `apis.sanaei.get_admin_token` (legacy) or `apis.sanaei_modern.get_admin_token` (modern cookie auth), and return `None` for modern bearer auth to indicate username/password refresh is unsupported.
- Updated `ensure_panel_access_token` to skip refresh attempts for modern Sanaei bearer-auth panels while preserving the configured bearer token and updating the fallback/hourly cooldown state instead of writing a new token.
- Extended SQL selects used by `refresh_panel_access_token_for_request` and various helper queries to include `sanaei_api_version` and `sanaei_auth_type`, and updated callers that feed `ensure_panel_tokens` (`scripts/usage_sync.py`, `bot.py`, `api/subscription_aggregator/flask_app.py`) to fetch the additional column.

### Testing
- Successfully type-checked/compiled modified modules with `python -m py_compile services/panel_tokens.py scripts/usage_sync.py bot.py api/subscription_aggregator/flask_app.py`.
- Attempted an environment sanity run that exercises `ensure_panel_access_token` and `_authenticator_for_panel_type` under `ENABLE_API_FAILURE_TOKEN_REFRESH=1`, but the run could not complete due to a missing `dotenv` dependency in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1efacd17248330877a1d26ef59ed39)