### PR TITLE
Map Sanaei creation payloads to modern client schema

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -109,6 +109,50 @@ def panel_username(panel_type: str, username: str) -> str:
         return value.lower()
     return value
 
+
+def build_sanaei_create_payload(
+    remote_name: str,
+    inbound_id: int | str,
+    limit_bytes: int = 0,
+    expire_ts: int = 0,
+    sanaei_api_version: str | None = None,
+) -> dict:
+    """Build a Sanaei user creation body for the configured API version.
+
+    Legacy Sanaei accepts an inbound ``id`` plus serialized
+    ``settings.clients``. Modern Sanaei's ``/panel/api/clients/add`` endpoint
+    expects a first-class client object and an ``inboundIds`` array.
+    """
+
+    client = {
+        "email": remote_name,
+        "enable": True,
+    }
+    if limit_bytes > 0:
+        client["totalGB"] = limit_bytes
+    if expire_ts > 0:
+        client["expiryTime"] = expire_ts * 1000
+
+    inbound_id = int(inbound_id)
+    if (sanaei_api_version or "").lower() == "modern":
+        return {
+            "client": {
+                **client,
+                "tgId": 0,
+                "limitIp": 0,
+            },
+            "inboundIds": [inbound_id],
+        }
+
+    legacy_client = {
+        "id": str(uuid.uuid4()),
+        **client,
+    }
+    return {
+        "id": inbound_id,
+        "settings": json.dumps({"clients": [legacy_client]}, separators=(",", ":")),
+    }
+
 # ---------- proxy helpers ----------
 def clone_proxy_settings(proxies: dict) -> dict:
     """Copy proxy settings and regenerate credentials.
@@ -3736,19 +3780,13 @@ async def finalize_create_on_selected(q, context, owner_id: int, selected_ids: s
             panel_failed = False
             for inb in inbound_ids:
                 rn = f"{app_username}_{secrets.token_hex(3)}"
-                client = {
-                    "id": str(uuid.uuid4()),
-                    "email": rn,
-                    "enable": True,
-                }
-                if limit_bytes > 0:
-                    client["totalGB"] = limit_bytes
-                if expire_ts > 0:
-                    client["expiryTime"] = expire_ts * 1000
-                payload = {
-                    "id": int(inb),
-                    "settings": json.dumps({"clients": [client]}, separators=(",", ":")),
-                }
+                payload = build_sanaei_create_payload(
+                    rn,
+                    inb,
+                    limit_bytes=limit_bytes,
+                    expire_ts=expire_ts,
+                    sanaei_api_version=r.get("sanaei_api_version"),
+                )
                 obj, e = api.create_user(r["panel_url"], r["access_token"], payload)
                 if not obj:
                     obj, g = api.get_user(r["panel_url"], r["access_token"], rn)
@@ -4037,19 +4075,13 @@ def sync_user_panels(owner_id: int, username: str, selected_ids: set):
                 remote_names = []
                 for inb in inb_ids:
                     remote_name = f"{username}_{secrets.token_hex(3)}"
-                    client = {
-                        "id": str(uuid.uuid4()),
-                        "email": remote_name,
-                        "enable": True,
-                    }
-                    if limit_bytes_default > 0:
-                        client["totalGB"] = limit_bytes_default
-                    if expire_ts_default > 0:
-                        client["expiryTime"] = expire_ts_default * 1000
-                    payload = {
-                        "id": int(inb),
-                        "settings": json.dumps({"clients": [client]}, separators=(",", ":")),
-                    }
+                    payload = build_sanaei_create_payload(
+                        remote_name,
+                        inb,
+                        limit_bytes=limit_bytes_default,
+                        expire_ts=expire_ts_default,
+                        sanaei_api_version=p.get("sanaei_api_version"),
+                    )
                     obj, e2 = api.create_user(p["panel_url"], p["access_token"], payload)
                     if not obj:
                         added_errs.append(f"{p['panel_url']} (inb {inb}): {e2 or 'unknown error'}")


### PR DESCRIPTION
### Motivation
- Modern Sanaei exposes first-class client endpoints (`/panel/api/clients/add`) that expect a `{ "client": {...}, "inboundIds": [...] }` body while legacy callers used an inbound `id` and serialized `settings.clients`; the bot was still sending legacy-shaped payloads for Sanaei panels.
- Ensure the bot constructs the correct payload shape depending on the configured `sanaei_api_version` so modern panels receive the documented client schema and legacy panels keep backward compatibility.

### Description
- Added `build_sanaei_create_payload()` to `bot.py` to centralize Sanaei create-payload construction and emit either modern `{client, inboundIds}` or legacy `{id, settings}` bodies depending on `sanaei_api_version` and provided params (`email`/`enable`, optional `totalGB`/`expiryTime`, plus `tgId`/`limitIp` defaults for modern). (`bot.py` L113-L154)
- Replaced inline legacy payload construction in the bot user creation flow (`finalize_create_on_selected`) to call the new builder so Sanaei panels configured as `modern` receive the modern schema. (`bot.py` L3778-L3790)
- Replaced inline legacy payload construction in the sync/add-panel path (`sync_user_panels`) to call the new builder as well, preserving legacy behavior for non-modern panels. (`bot.py` L4073-L4085)

### Testing
- Ran `python -m py_compile bot.py apis/sanaei_modern.py` which succeeded. (ok)
- Parsed `bot.py` with `ast.parse(...)` which succeeded. (ok)
- Ran `git diff --check` which reported no whitespace or diff check issues. (ok)
- Executed a small runtime assertion script that would import and exercise `build_sanaei_create_payload`, but importing the full `bot` module failed in the test environment due to a missing external dependency (`werkzeug`), so the runtime assertions were not executed here. (blocked by environment dependency)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1efcd818ac83319baec1429abdc735)