### PR TITLE
Ensure DB schema is applied before usage-sync worker starts

### DIFF
--- a/scripts/usage_sync.py
+++ b/scripts/usage_sync.py
@@ -10,7 +10,7 @@ from datetime import datetime, timezone, timedelta
 
 from dotenv import load_dotenv
 from services import init_mysql_pool, with_mysql_cursor
-from services.database import mysql_errors
+from services.database import ensure_schema, mysql_errors
 from services.panel_tokens import ensure_panel_tokens
 from services.settings import get_setting as get_owner_setting
 
@@ -968,6 +968,7 @@ def loop():
 def main():
     load_dotenv()
     init_mysql_pool()
+    ensure_schema()
     ensure_agent_panel_usage_totals_table()
     loop()
 


### PR DESCRIPTION
### Motivation
- The usage sync worker queries `panels` columns (e.g. `sanaei_api_version`) that may be added by migrations, which can cause `Unknown column` MySQL errors when the schema is not present. 

### Description
- Import the shared schema initializer from `services.database` as `ensure_schema` in `scripts/usage_sync.py`.  
- Call `ensure_schema()` during the worker startup before `ensure_agent_panel_usage_totals_table()` and the main sync `loop()` so required tables and columns are created before queries run.  
- Change is limited to `scripts/usage_sync.py` and only affects startup ordering to run migrations earlier. 

### Testing
- Ran `git diff --check` to validate no trailing issues and it passed.  
- Compiled the modified modules with `python -m py_compile scripts/usage_sync.py services/database.py` and it succeeded.  
- Attempted to import `scripts.usage_sync` with `python - <<'PY'\nimport scripts.usage_sync as usage_sync\nprint(usage_sync.ensure_schema.__name__)\nPY` but this was blocked by a missing local `requests` dependency in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f009541dc8331985ece4d903b33ea)