### PR TITLE
Rollback web user creation on panel sync errors

### DIFF
--- a/api/routes/web_auth.py
+++ b/api/routes/web_auth.py
@@ -39,6 +39,7 @@ from api.users import (
 )
 from bot import (
     build_sub_links,
+    delete_local_user,
     delete_user,
     get_app_key,
     list_services_for_owner,
@@ -633,9 +634,25 @@ async def web_create_user(
             detail="minimum limit is 20GB for services that include a GuardCore panel",
         )
 
+    local_user_existed = _fetch_user(scoped_owner_id, payload.username) is not None
     upsert_local_user(scoped_owner_id, payload.username, payload.limit_bytes, payload.duration_days)
+    sync_errors: list[str] = []
     if payload.service_id is not None:
-        await set_local_user_service(scoped_owner_id, payload.username, payload.service_id)
+        sync_errors = await set_local_user_service(
+            scoped_owner_id,
+            payload.username,
+            payload.service_id,
+            rollback_on_error=True,
+        )
+    if sync_errors:
+        if not local_user_existed:
+            delete_local_user(scoped_owner_id, payload.username)
+        detail = (
+            "❌ ساخت کاربر موفق نبود و تمام کاربران ساخته‌شده از پنل‌های دیگر حذف شدند."
+            "\n⚠️ خطاها:\n"
+            + "\n".join(f"• {error}" for error in sync_errors[:8])
+        )
+        raise HTTPException(status_code=409, detail=detail)
 
     row = _fetch_user(scoped_owner_id, payload.username)
     if not row:

--- a/api/subscription_aggregator/static/web-ui.tsx
+++ b/api/subscription_aggregator/static/web-ui.tsx
@@ -1029,6 +1029,7 @@ function UsersPage() {
   const handleAction = async (payload: any) => {
     if (!selectedUser) return;
     setBusy(true);
+    setError('');
     try {
       const res = await fetch(`/api/v1/web/users/${encodeURIComponent(selectedUser.username)}`, {
         method: payload.delete ? 'DELETE' : 'PATCH',
@@ -1246,10 +1247,12 @@ function CreateUserModal({ services, onClose, onSuccess }: { services: ServiceRe
   const [days, setDays] = useState('');
   const [serviceId, setServiceId] = useState('');
   const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
     setBusy(true);
+    setError('');
     try {
       const res = await fetch('/api/v1/web/users', {
         method: 'POST',
@@ -1262,9 +1265,14 @@ function CreateUserModal({ services, onClose, onSuccess }: { services: ServiceRe
           service_id: serviceId ? Number(serviceId) : null,
         }),
       });
-      if (res.ok) onSuccess(); else alert('Failed to create user');
+      if (res.ok) {
+        onSuccess();
+      } else {
+        const data = await res.json().catch(() => ({}));
+        setError(typeof data.detail === 'string' ? data.detail : 'Failed to create user');
+      }
     } catch {
-      alert('Error occurred');
+      setError('Error occurred');
     } finally {
       setBusy(false);
     }
@@ -1301,6 +1309,11 @@ function CreateUserModal({ services, onClose, onSuccess }: { services: ServiceRe
               {services.map(s => <option key={s.id} value={s.id}>{s.name}</option>)}
             </select>
           </div>
+          {error && (
+            <div className="whitespace-pre-wrap rounded-xl border border-rose-200 bg-rose-50 p-3 text-sm font-medium text-rose-700 dark:border-rose-900/60 dark:bg-rose-950/40 dark:text-rose-200">
+              {error}
+            </div>
+          )}
           <div className="flex gap-3 pt-2">
             <button type="button" onClick={onClose} className={btnSecondary + " flex-1"}>Cancel</button>
             <button type="submit" disabled={busy} className={btnPrimary + " flex-1"}>{busy ? 'Creating...' : 'Create User'}</button>

--- a/bot.py
+++ b/bot.py
@@ -706,13 +706,19 @@ def resolve_local_user_owner(owner_id: int, username: str) -> int | None:
         return int(row["owner_id"]) if row else None
 
 
-async def set_local_user_service(owner_id: int, username: str, service_id: int | None):
+async def set_local_user_service(
+    owner_id: int,
+    username: str,
+    service_id: int | None,
+    *,
+    rollback_on_error: bool = False,
+) -> list[str]:
     real_owner = resolve_local_user_owner(owner_id, username)
     if real_owner is None:
         log.info(
             "set_local_user_service skip: owner=%s username=%s not found", owner_id, username
         )
-        return
+        return []
 
     params: list[object] = [service_id, real_owner, username]
     with with_mysql_cursor(dict_=False) as cur:
@@ -721,7 +727,9 @@ async def set_local_user_service(owner_id: int, username: str, service_id: int |
             params,
         )
     pids = list_service_panel_ids(service_id) if service_id else set()
-    await sync_user_panels_async(real_owner, username, pids)
+    return await sync_user_panels_async(
+        real_owner, username, pids, rollback_on_error=rollback_on_error
+    )
 
 async def propagate_service_panels(service_id: int):
     """After service panels change, update agents/users accordingly."""
@@ -4035,7 +4043,13 @@ async def finalize_create_on_selected(q, context, owner_id: int, selected_ids: s
         txt += "\n⚠️ خطاها:\n" + "\n".join(f"• {e}" for e in failed[:8])
     await q.edit_message_text(txt)
 
-def sync_user_panels(owner_id: int, username: str, selected_ids: set):
+def sync_user_panels(
+    owner_id: int,
+    username: str,
+    selected_ids: set,
+    *,
+    rollback_on_error: bool = False,
+) -> list[str]:
     lu = get_local_user(owner_id, username)
     if not lu:
         links_map = map_linked_remote_usernames(owner_id, username)
@@ -4071,7 +4085,7 @@ def sync_user_panels(owner_id: int, username: str, selected_ids: set):
                             err or "unknown error",
                         )
         log.info("sync_user_panels skip missing local user %s/%s", owner_id, username)
-        return
+        return []
 
     links_map = map_linked_remote_usernames(owner_id, username)
     current = set(links_map.keys())
@@ -4334,6 +4348,34 @@ def sync_user_panels(owner_id: int, username: str, selected_ids: set):
                 links_map[int(pid)] = username
                 added_ok += 1
 
+    if rollback_on_error and added_errs:
+        for pid in sorted(to_add):
+            remote = links_map.get(int(pid))
+            panel = panels_map.get(int(pid))
+            if not remote or not panel:
+                continue
+            api = get_api(panel.get("panel_type"), panel.get("sanaei_api_version"))
+            for rn in remote_names_for_panel(panel, remote):
+                ok_rm, err_rm = api.remove_remote_user(
+                    panel["panel_url"], panel["access_token"], rn
+                )
+                if not ok_rm:
+                    log.warning(
+                        "sync_user_panels rollback failed removing %s from %s: %s",
+                        rn,
+                        panel.get("panel_url"),
+                        err_rm or "unknown error",
+                    )
+            remove_link(owner_id, username, int(pid))
+            links_map.pop(int(pid), None)
+        log.warning(
+            "sync_user_panels rolled back %s/%s because of errors: %s",
+            owner_id,
+            username,
+            "; ".join(added_errs[:10]),
+        )
+        return added_errs
+
     if to_remove:
         for pid in to_remove:
             p = panels_map.get(int(pid))
@@ -4403,11 +4445,24 @@ def sync_user_panels(owner_id: int, username: str, selected_ids: set):
     )
     if added_errs:
         log.warning("sync_user_panels errors: %s", "; ".join(added_errs[:10]))
+    return added_errs
 
-async def sync_user_panels_async(owner_id: int, username: str, selected_ids: set):
+async def sync_user_panels_async(
+    owner_id: int,
+    username: str,
+    selected_ids: set,
+    *,
+    rollback_on_error: bool = False,
+) -> list[str]:
     """Run sync_user_panels in a thread to avoid blocking the event loop."""
-    loop = asyncio.get_running_loop()
-    await loop.run_in_executor(None, sync_user_panels, owner_id, username, selected_ids)
+
+    return await asyncio.to_thread(
+        sync_user_panels,
+        owner_id,
+        username,
+        selected_ids,
+        rollback_on_error=rollback_on_error,
+    )
 
 # ---------- wiring ----------
 def build_app():


### PR DESCRIPTION
### Motivation
- When web UI creates a local user and then fails to create/enable the corresponding remote users on configured panels, the web flow should mirror the bot: rollback any successfully-created remote users, remove the local user if it was newly-created, and surface the same Persian failure message to the web UI.

### Description
- Added rollback-aware panel sync by changing `sync_user_panels` to return `list[str]` errors and accept `rollback_on_error: bool`, and added `sync_user_panels_async(..., rollback_on_error=...)` to run it from async contexts (`bot.py`).
- Updated `set_local_user_service` to return sync errors and accept `rollback_on_error: bool`, preserving existing behavior when `rollback_on_error` is `False` (`bot.py`).
- Updated web create user endpoint to call `set_local_user_service(..., rollback_on_error=True)`, delete the newly-created local user on sync failure, and raise `HTTPException(status_code=409)` with the same Persian formatted error message used by the bot (`api/routes/web_auth.py`).
- Improved the web UI create-user modal to display backend failure details inline instead of a generic alert so panel errors are visible to the operator (`api/subscription_aggregator/static/web-ui.tsx`).

### Testing
- Compiled modified modules with `python -m compileall api/routes/web_auth.py api/users.py bot.py` and the compilation succeeded without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20dc7c21908326af7557ff43a696e1)