### PR TITLE
Fix Sanaei duplicate client handling

### DIFF
--- a/apis/sanaei_modern.py
+++ b/apis/sanaei_modern.py
@@ -98,7 +98,21 @@ def _unwrap_panel_response(data: Any) -> Any:
 
 
 def _panel_success(data: Any) -> bool:
-    return not isinstance(data, Mapping) or data.get("success", True) is not False
+    """Return whether a wrapped 3x-ui response is successful.
+
+    Some panel forks encode ``success`` as strings or integers instead of a
+    JSON boolean.  Treat every explicit false-like value as a failure so
+    ``{"success": false, ...}`` responses, including duplicate-email
+    errors from ``/panel/api/clients/add``, never get normalised into a
+    successful client object.
+    """
+
+    if not isinstance(data, Mapping) or "success" not in data:
+        return True
+    success = data.get("success")
+    if isinstance(success, str):
+        return success.strip().lower() not in {"", "0", "false", "no", "off"}
+    return bool(success)
 
 
 def _json_or_empty(response: requests.Response) -> Any:

--- a/bot.py
+++ b/bot.py
@@ -161,6 +161,30 @@ def remote_names_for_panel(panel: dict | None, remote_username: str) -> list[str
     return [remote_username]
 
 
+def is_duplicate_create_error(error: object) -> bool:
+    """Return True when a panel rejected creation because the name exists.
+
+    User-creation flows sometimes fetch the remote user after a failed create to
+    recover from ambiguous network/panel responses.  Duplicate-name responses
+    are not ambiguous: treating the existing remote user as the newly created
+    user can attach this bot record to another customer's subscription.
+    """
+
+    text = str(error or "").casefold()
+    if not text:
+        return False
+    duplicate_markers = (
+        "already exists",
+        "already in use",
+        "duplicate",
+        "409",
+    )
+    identity_markers = ("email", "username", "user", "client", "subscription")
+    return any(marker in text for marker in duplicate_markers) and any(
+        marker in text for marker in identity_markers
+    )
+
+
 def _normalise_sanaei_inbound_ids(inbound_ids: int | str | list | tuple | set) -> list[int]:
     if isinstance(inbound_ids, (list, tuple, set)):
         values = inbound_ids
@@ -3967,6 +3991,10 @@ async def finalize_create_on_selected(q, context, owner_id: int, selected_ids: s
                 )
                 obj, e = api.create_user(r["panel_url"], r["access_token"], payload)
                 if not obj:
+                    if is_duplicate_create_error(e):
+                        failed.append(f"{r['panel_url']} (inb {inb}): {e or 'duplicate user'}")
+                        panel_failed = True
+                        continue
                     obj, g = api.get_user(r["panel_url"], r["access_token"], rn)
                     if not obj:
                         failed.append(f"{r['panel_url']} (inb {inb}): {e or g or 'unknown error'}")
@@ -4010,6 +4038,9 @@ async def finalize_create_on_selected(q, context, owner_id: int, selected_ids: s
                     payload["group_ids"] = list(groups)
         obj, e = api.create_user(r["panel_url"], r["access_token"], payload)
         if not obj:
+            if is_duplicate_create_error(e):
+                failed.append(f"{r['panel_url']}: {e or 'duplicate user'}")
+                continue
             obj, g = api.get_user(r["panel_url"], r["access_token"], remote_name)
             if not obj:
                 failed.append(f"{r['panel_url']}: {e or g or 'unknown error'}")
@@ -4178,6 +4209,9 @@ def sync_user_panels(
                 }
                 obj, e2 = api.create_user(p["panel_url"], p["access_token"], payload)
                 if not obj:
+                    if is_duplicate_create_error(e2):
+                        added_errs.append(f"{p['panel_url']}: {e2 or 'duplicate user'}")
+                        continue
                     obj, g = api.get_user(p["panel_url"], p["access_token"], username)
                     if not obj:
                         added_errs.append(f"{p['panel_url']}: {e2 or g or 'unknown error'}")
@@ -4231,6 +4265,9 @@ def sync_user_panels(
                 }
                 obj, e2 = api.create_user(p["panel_url"], p["access_token"], payload)
                 if not obj:
+                    if is_duplicate_create_error(e2):
+                        added_errs.append(f"{p['panel_url']}: {e2 or 'duplicate user'}")
+                        continue
                     obj, g = api.get_user(p["panel_url"], p["access_token"], remote_username)
                     if not obj:
                         added_errs.append(f"{p['panel_url']}: {e2 or g or 'unknown error'}")

--- a/tests/test_sanaei_modern.py
+++ b/tests/test_sanaei_modern.py
@@ -1,0 +1,89 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+
+def _load_sanaei_modern():
+    requests_stub = types.SimpleNamespace(Session=lambda: Mock())
+    cachetools_stub = types.SimpleNamespace(
+        TTLCache=lambda *args, **kwargs: {},
+        cached=lambda cache=None, lock=None: (lambda func: func),
+    )
+    services_pkg = types.ModuleType("services")
+    panel_tokens_stub = types.ModuleType("services.panel_tokens")
+    panel_tokens_stub.refresh_panel_access_token_for_request = lambda *args, **kwargs: None
+
+    originals = {name: sys.modules.get(name) for name in ("requests", "cachetools", "services", "services.panel_tokens")}
+    sys.modules["requests"] = requests_stub
+    sys.modules["cachetools"] = cachetools_stub
+    sys.modules["services"] = services_pkg
+    sys.modules["services.panel_tokens"] = panel_tokens_stub
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "sanaei_modern_under_test", Path(__file__).resolve().parents[1] / "apis" / "sanaei_modern.py"
+        )
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for name, original in originals.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+
+
+sanaei_modern = _load_sanaei_modern()
+
+
+class SanaeiModernResponseTests(unittest.TestCase):
+    def test_panel_success_rejects_false_like_values(self):
+        false_values = [False, 0, "false", "False", "0", "", " no ", "off"]
+        for value in false_values:
+            with self.subTest(value=value):
+                self.assertFalse(sanaei_modern._panel_success({"success": value}))
+
+    def test_create_user_does_not_treat_failed_duplicate_response_as_success(self):
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = {
+            "success": False,
+            "msg": "Something went wrong (email already in use: bugtest-a7f93d2c\n)",
+            "obj": None,
+        }
+
+        payload = {
+            "client": {"email": "bugtest-a7f93d2c", "enable": True},
+            "inboundIds": [7],
+        }
+
+        with patch.object(sanaei_modern, "_fetch_all_client_emails", return_value=(set(), None)), patch.object(
+            sanaei_modern, "_request_with_reauth", return_value=response
+        ):
+            obj, err = sanaei_modern.create_user("https://panel.example", "token", payload)
+
+        self.assertIsNone(obj)
+        self.assertIn("email already in use", err)
+
+    def test_create_user_rejects_duplicate_found_before_post(self):
+        payload = {
+            "client": {"email": "bugtest-a7f93d2c", "enable": True},
+            "inboundIds": [7],
+        }
+
+        with patch.object(
+            sanaei_modern, "_fetch_all_client_emails", return_value=({"bugtest-a7f93d2c"}, None)
+        ), patch.object(sanaei_modern, "_request_with_reauth") as request:
+            obj, err = sanaei_modern.create_user("https://panel.example", "token", payload)
+
+        self.assertIsNone(obj)
+        self.assertIn("already exists", err)
+        request.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Modern 3x-ui (Sanaei) forks sometimes encode `success` as strings/ints or return explicit failure messages for duplicate emails, which must be treated as failures so the bot does not misinterpret them as successful creations.
- When a create call fails with a duplicate-identity error, falling back to `get_user()` and treating the existing remote user as newly created can attach a different customer's remote account to the local record, so duplicate-create responses must not trigger that recovery flow.

### Description
- Update `_panel_success` in `apis/sanaei_modern.py` to treat explicit false-like `success` values (`"false"`, `0`, `"0"`, empty, `"no"`, `"off"`, etc.) as failures so error responses are not normalized into successful objects.
- Add `is_duplicate_create_error` helper in `bot.py` and use it in user-creation code paths to detect duplicate-email/name errors and avoid falling back to `get_user()` (preventing accidental attachment of existing remote users).
- Add unit tests in `tests/test_sanaei_modern.py` that assert `_panel_success` rejects false-like values and that `create_user` properly rejects duplicate-email results both when detected before the POST and when returned from the POST.

### Testing
- Ran unit tests with `python -m unittest discover -s tests`, which passed (tests in `tests/test_sanaei_modern.py` executed OK).
- Verified syntax by compiling with `python -m py_compile apis/sanaei_modern.py bot.py tests/test_sanaei_modern.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a220ecd1c3c8330b26205cea4171a10)