### PR TITLE
Scoped subscription placeholder fallback

### DIFF
--- a/api/subscription_aggregator/flask_app.py
+++ b/api/subscription_aggregator/flask_app.py
@@ -28,9 +28,9 @@ from datetime import datetime
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from services import ensure_panel_tokens, init_mysql_pool, with_mysql_cursor
 from services.database import errorcode, mysql_errors
-from services.settings import get_setting as get_owner_setting
+from services.settings import get_setting as get_owner_setting, get_setting_exact
 from apis import sanaei, sanaei_modern, pasarguard, rebecca, guardcore
-from .ownership import expand_owner_ids, canonical_owner_id
+from .ownership import expand_owner_ids, canonical_owner_id, ordered_admin_ids
 
 logging.basicConfig(
     format="%(asctime)s | %(levelname)s | flask_agg | %(message)s",
@@ -802,11 +802,39 @@ def _replace_placeholders(template: str, values: dict[str, str]) -> str:
     return re.sub(r"\{([A-Z0-9_]+)\}", repl, template, flags=re.IGNORECASE)
 
 
-def build_sub_placeholder_config(owner_id: int, local_username: str, lu) -> str | None:
-    enabled = (get_setting(owner_id, SUB_PLACEHOLDER_ENABLED_KEY) or "0") != "0"
-    if not enabled:
+def _root_admin_id() -> int | None:
+    admins = ordered_admin_ids()
+    return admins[0] if admins else None
+
+
+def _exact_setting(owner_id: int | None, key: str) -> str | None:
+    if owner_id is None:
         return None
-    template = (get_setting(owner_id, SUB_PLACEHOLDER_TEMPLATE_KEY) or "").strip()
+    return get_setting_exact(int(owner_id), key)
+
+
+def _effective_sub_placeholder_enabled(owner_id: int) -> bool:
+    root_id = _root_admin_id()
+    raw = _exact_setting(owner_id, SUB_PLACEHOLDER_ENABLED_KEY)
+    if raw is None and root_id is not None and int(owner_id) != root_id:
+        raw = _exact_setting(root_id, SUB_PLACEHOLDER_ENABLED_KEY)
+    return (raw or "0") != "0"
+
+
+def _effective_sub_placeholder_template(owner_id: int) -> str:
+    root_id = _root_admin_id()
+    template = (_exact_setting(owner_id, SUB_PLACEHOLDER_TEMPLATE_KEY) or "").strip()
+    if template:
+        return template
+    if root_id is not None and int(owner_id) != root_id:
+        return (_exact_setting(root_id, SUB_PLACEHOLDER_TEMPLATE_KEY) or "").strip()
+    return ""
+
+
+def build_sub_placeholder_config(owner_id: int, local_username: str, lu) -> str | None:
+    if not _effective_sub_placeholder_enabled(owner_id):
+        return None
+    template = _effective_sub_placeholder_template(owner_id)
     if not template:
         return None
 

--- a/bot.py
+++ b/bot.py
@@ -50,6 +50,7 @@ from telegram.ext import (
 
 from api.subscription_aggregator import (
     admin_ids,
+    ordered_admin_ids,
     expand_owner_ids,
     canonical_owner_id,
 )
@@ -69,6 +70,7 @@ from services import (
     renew_agent_days,
     set_agent_active,
     get_setting,
+    get_setting_exact,
     set_setting,
     TokenEncryptionError as PanelTokenEncryptionError,
     encrypt_panel_password,
@@ -520,8 +522,39 @@ def _sanaei_version_kb() -> InlineKeyboardMarkup:
 def _sanaei_auth_type_kb() -> InlineKeyboardMarkup:
     return _choice_kb(SANAEI_AUTH_TYPE_LABELS, "add_sanaei_auth")
 
+def _root_admin_id() -> int | None:
+    admins = ordered_admin_ids()
+    return admins[0] if admins else None
+
+
+def _exact_owner_setting(owner_id: int | None, key: str) -> str | None:
+    if owner_id is None:
+        return None
+    return get_setting_exact(int(owner_id), key)
+
+
+def _effective_sub_placeholder_enabled(owner_id: int) -> bool:
+    root_id = _root_admin_id()
+    raw = _exact_owner_setting(owner_id, "subscription_placeholder_enabled")
+    if raw is None and root_id is not None and int(owner_id) != root_id:
+        raw = _exact_owner_setting(root_id, "subscription_placeholder_enabled")
+    return (raw or "0") != "0"
+
+
+def _effective_sub_placeholder_template(owner_id: int) -> tuple[str, int | None]:
+    root_id = _root_admin_id()
+    own = (_exact_owner_setting(owner_id, "subscription_placeholder_template") or "").strip()
+    if own:
+        return own, int(owner_id)
+    if root_id is not None and int(owner_id) != root_id:
+        root = (_exact_owner_setting(root_id, "subscription_placeholder_template") or "").strip()
+        if root:
+            return root, root_id
+    return "", None
+
+
 def _sub_placeholder_toggle_label(owner_id: int) -> str:
-    enabled = (get_setting(owner_id, "subscription_placeholder_enabled") or "0") != "0"
+    enabled = _effective_sub_placeholder_enabled(owner_id)
     return "🟢 Sub Placeholder: ON" if enabled else "🔴 Sub Placeholder: OFF"
 
 def _agent_technical_kb(owner_id: int) -> InlineKeyboardMarkup:
@@ -1731,7 +1764,7 @@ async def on_button(update: Update, context: ContextTypes.DEFAULT_TYPE):
         if not is_admin(uid) and not get_agent(uid):
             await q.edit_message_text("دسترسی ندارید.")
             return ConversationHandler.END
-        current = (get_setting(uid, "subscription_placeholder_enabled") or "0") != "0"
+        current = _effective_sub_placeholder_enabled(uid)
         set_setting(uid, "subscription_placeholder_enabled", "0" if current else "1")
         if is_admin(uid):
             await q.edit_message_text("Technical:", reply_markup=_admin_technical_kb(uid))
@@ -1810,13 +1843,20 @@ async def on_button(update: Update, context: ContextTypes.DEFAULT_TYPE):
         if not is_admin(uid) and not get_agent(uid):
             await q.edit_message_text("دسترسی ندارید.")
             return ConversationHandler.END
-        cur = get_setting(uid, "subscription_placeholder_template") or "—"
+        own_template = (_exact_owner_setting(uid, "subscription_placeholder_template") or "").strip()
+        effective_template, template_owner = _effective_sub_placeholder_template(uid)
+        if own_template:
+            cur = own_template
+        elif effective_template and template_owner is not None and template_owner != uid:
+            cur = f"{effective_template}\n\n(از قالب root admin استفاده می‌شود؛ برای اختصاصی کردن، قالب جدید بفرست.)"
+        else:
+            cur = "—"
         back_target = "admin_technical" if is_admin(uid) else "agent_technical"
         await q.edit_message_text(
             "قالب فعلی:\n"
             f"{cur}\n\n"
             "قالب جدید را بفرست.\n"
-            "برای حذف: clear",
+            "برای حذف قالب اختصاصی و استفاده از root admin: clear",
             reply_markup=_back_kb(back_target),
         )
         return ASK_SUB_PLACEHOLDER_TEMPLATE

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -14,7 +14,7 @@ from .quotas import (
     renew_agent_days,
     set_agent_active,
 )
-from .settings import get_setting, set_setting, delete_setting
+from .settings import get_setting, get_setting_exact, set_setting, delete_setting
 from .panel_tokens import (
     TokenEncryptionError,
     decrypt_panel_password,
@@ -38,6 +38,7 @@ __all__ = [
     "renew_agent_days",
     "set_agent_active",
     "get_setting",
+    "get_setting_exact",
     "set_setting",
     "delete_setting",
     "TokenEncryptionError",

--- a/services/settings.py
+++ b/services/settings.py
@@ -10,6 +10,33 @@ log = logging.getLogger(__name__)
 _settings_table_missing_logged = False
 
 
+def get_setting_exact(owner_id: int, key: str) -> Optional[str]:
+    """Return a setting stored exactly for one owner, without admin fallback."""
+    with with_mysql_cursor() as cur:
+        try:
+            cur.execute(
+                """
+                SELECT `value`
+                FROM settings
+                WHERE owner_id=%s AND `key`=%s
+                LIMIT 1
+                """,
+                (owner_id, key),
+            )
+        except mysql_errors.ProgrammingError as exc:
+            if getattr(exc, "errno", None) == errorcode.ER_NO_SUCH_TABLE:
+                global _settings_table_missing_logged
+                if not _settings_table_missing_logged:
+                    log.warning(
+                        "settings table missing; returning no setting values until it is created"
+                    )
+                    _settings_table_missing_logged = True
+                return None
+            raise
+        row = cur.fetchone()
+    return row["value"] if row else None
+
+
 def get_setting(owner_id: int, key: str) -> Optional[str]:
     from api.subscription_aggregator.ownership import ordered_admin_ids
 


### PR DESCRIPTION
### Motivation
- Ensure subscription placeholder templates behave per-owner: an agent may set a template for their users, otherwise the root admin template should be used, and if neither exists no placeholder is emitted.
- Avoid unintentional admin/global fallback when code needs to know whether an owner explicitly set a value.

### Description
- Added `get_setting_exact(owner_id, key)` to `services.settings` to read a setting for a specific owner without admin/global fallback and exported it via `services.__init__`.
- Implemented owner-scoped resolution helpers (`_exact_setting`, `_root_admin_id`, `_effective_sub_placeholder_enabled`, `_effective_sub_placeholder_template`) in `api/subscription_aggregator/flask_app.py` and changed `build_sub_placeholder_config` to use them so the placeholder is produced only when enabled and a template exists (owner first, root-admin fallback second).
- Updated bot UI logic in `bot.py` to: show the effective enabled state, allow toggling against the effective value, display the owner template when present, and indicate when the root-admin template is being used (with guidance about overriding it by providing a custom template).

### Testing
- Ran `python -m compileall services api bot.py` which completed without error.
- Ran `pytest -q` which passed: `3 passed, 8 subtests passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a221efd290483309cdcf671146b7eee)