### PR TITLE
Fix root admin sub placeholder fallback

### DIFF
--- a/api/subscription_aggregator/flask_app.py
+++ b/api/subscription_aggregator/flask_app.py
@@ -813,9 +813,30 @@ def _exact_setting(owner_id: int | None, key: str) -> str | None:
     return get_setting_exact(int(owner_id), key)
 
 
+def _legacy_root_admin_setting(owner_id: int, key: str) -> str | None:
+    """Return a pre-scoped admin setting when the root admin has no exact row.
+
+    Admin-owned records have historically been shared across every ADMIN_IDS
+    entry.  After placeholder settings became exact-owner scoped, a root admin
+    can still have the old value stored under a secondary admin id.  Only the
+    root admin gets this compatibility fallback so secondary admins keep their
+    own placeholder scope.
+    """
+    admins = ordered_admin_ids()
+    if not admins or int(owner_id) != admins[0]:
+        return None
+    for admin_id in admins[1:]:
+        value = _exact_setting(admin_id, key)
+        if value is not None:
+            return value
+    return None
+
+
 def _effective_sub_placeholder_enabled(owner_id: int) -> bool:
     root_id = _root_admin_id()
     raw = _exact_setting(owner_id, SUB_PLACEHOLDER_ENABLED_KEY)
+    if raw is None:
+        raw = _legacy_root_admin_setting(owner_id, SUB_PLACEHOLDER_ENABLED_KEY)
     if raw is None and root_id is not None and int(owner_id) != root_id:
         raw = _exact_setting(root_id, SUB_PLACEHOLDER_ENABLED_KEY)
     return (raw or "0") != "0"
@@ -824,6 +845,9 @@ def _effective_sub_placeholder_enabled(owner_id: int) -> bool:
 def _effective_sub_placeholder_template(owner_id: int) -> str:
     root_id = _root_admin_id()
     template = (_exact_setting(owner_id, SUB_PLACEHOLDER_TEMPLATE_KEY) or "").strip()
+    if template:
+        return template
+    template = (_legacy_root_admin_setting(owner_id, SUB_PLACEHOLDER_TEMPLATE_KEY) or "").strip()
     if template:
         return template
     if root_id is not None and int(owner_id) != root_id:

--- a/bot.py
+++ b/bot.py
@@ -533,9 +533,30 @@ def _exact_owner_setting(owner_id: int | None, key: str) -> str | None:
     return get_setting_exact(int(owner_id), key)
 
 
+def _legacy_root_admin_setting(owner_id: int, key: str) -> tuple[str | None, int | None]:
+    """Return a pre-scoped admin setting when the root admin has no exact row.
+
+    Admin-owned records have historically been shared across every ADMIN_IDS
+    entry.  After placeholder settings became exact-owner scoped, a root admin
+    can still have the old value stored under a secondary admin id.  Only the
+    root admin gets this compatibility fallback so secondary admins keep their
+    own placeholder scope.
+    """
+    admins = ordered_admin_ids()
+    if not admins or int(owner_id) != admins[0]:
+        return None, None
+    for admin_id in admins[1:]:
+        value = _exact_owner_setting(admin_id, key)
+        if value is not None:
+            return value, admin_id
+    return None, None
+
+
 def _effective_sub_placeholder_enabled(owner_id: int) -> bool:
     root_id = _root_admin_id()
     raw = _exact_owner_setting(owner_id, "subscription_placeholder_enabled")
+    if raw is None:
+        raw, _ = _legacy_root_admin_setting(owner_id, "subscription_placeholder_enabled")
     if raw is None and root_id is not None and int(owner_id) != root_id:
         raw = _exact_owner_setting(root_id, "subscription_placeholder_enabled")
     return (raw or "0") != "0"
@@ -546,6 +567,10 @@ def _effective_sub_placeholder_template(owner_id: int) -> tuple[str, int | None]
     own = (_exact_owner_setting(owner_id, "subscription_placeholder_template") or "").strip()
     if own:
         return own, int(owner_id)
+    legacy, legacy_owner = _legacy_root_admin_setting(owner_id, "subscription_placeholder_template")
+    legacy_template = (legacy or "").strip()
+    if legacy_template:
+        return legacy_template, legacy_owner
     if root_id is not None and int(owner_id) != root_id:
         root = (_exact_owner_setting(root_id, "subscription_placeholder_template") or "").strip()
         if root:


### PR DESCRIPTION
### Motivation
- Root-admin subscription placeholder settings became owner-scoped and the root admin (first ID in `ADMIN_IDS`) lost visibility of a previously-stored value that remained under a secondary admin ID, so the UI and aggregator could show the placeholder as disabled even when an older value existed.

### Description
- Add a compatibility fallback `_legacy_root_admin_setting` to `api/subscription_aggregator/flask_app.py` that searches secondary `ADMIN_IDS` entries when the root admin has no exact setting row, and use it from `_effective_sub_placeholder_enabled` and `_effective_sub_placeholder_template`.
- Implement the same fallback logic in the Telegram bot helpers (`bot.py`) via `_legacy_root_admin_setting` and update `_effective_sub_placeholder_enabled` and `_effective_sub_placeholder_template` so the root admin sees the effective ON/OFF state and template (including indicating when a root template from another admin is being used).
- Use the exact-owner accessor `get_setting_exact` for precise lookups and preserve existing behavior for secondary admins and the general admin fallback.

### Testing
- Ran `python -m py_compile bot.py api/subscription_aggregator/flask_app.py` which succeeded.
- Ran the test suite with `pytest -q` and all tests passed (`3 passed, 8 subtests`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22213989248330b59ce320f27b9e33)