### PR TITLE
Fix Sanaei modern user updates and user-edit flows

### DIFF
--- a/apis/sanaei_modern.py
+++ b/apis/sanaei_modern.py
@@ -131,6 +131,12 @@ def _coerce_int(value: Any) -> Optional[int]:
         return None
 
 
+def _coerce_bool(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.strip().lower() not in {"", "0", "false", "no", "off"}
+    return bool(value)
+
+
 def _first_present(obj: Mapping[str, Any], *keys: str) -> Any:
     for key in keys:
         if key in obj and obj.get(key) is not None:
@@ -206,7 +212,7 @@ def _normalise_user_object(client_obj: Any, traffic_obj: Any = None, links: Opti
         status = str(client.get("status") or "").lower()
         enabled = status not in {"disabled", "limited", "expired", "depleted"}
     else:
-        enabled = bool(enabled_value)
+        enabled = _coerce_bool(enabled_value)
 
     normalised = dict(client)
     normalised.update(
@@ -492,15 +498,63 @@ def fetch_subscription_links(sub_url: str) -> List[str]:
     except Exception:  # pragma: no cover - network errors
         return []
 
+_MODERN_CLIENT_UPDATE_DROP_FIELDS = {
+    # These can be present in /panel/api/clients/get, /traffic, or our normalised
+    # object, but docs/sanaei-new-version.json says /clients/update/{email}
+    # expects the JSON client payload only.
+    "inboundIds",
+    "inbound_ids",
+    "inbounds",
+    "client",
+    "user",
+    "traffic",
+    "links",
+    "urls",
+    "subscription_url",
+    "subscriptionUrl",
+    "subUrl",
+    "used_traffic",
+    "usedTraffic",
+    "used",
+    "up",
+    "down",
+    "upload",
+    "download",
+    "uplink",
+    "downlink",
+    "enabled",
+    "data_limit",
+    "dataLimit",
+    "expiry_time",
+    "expire",
+    "expireTime",
+    "uuid",
+    "username",
+}
+
+
+def _prepare_update_payload(current: Any, username: str, changes: Mapping[str, Any]) -> Dict[str, Any]:
+    client = _extract_client(current)
+    if not client:
+        return {}
+    body = {key: value for key, value in client.items() if key not in _MODERN_CLIENT_UPDATE_DROP_FIELDS}
+    if client.get("enable") is None and client.get("enabled") is not None:
+        body["enable"] = _coerce_bool(client.get("enabled"))
+    body.update({key: value for key, value in changes.items() if value is not None})
+    if body.get("email") is None:
+        body["email"] = _first_present(client, "email", "username") or username
+    if body.get("enable") is not None:
+        body["enable"] = _coerce_bool(body.get("enable"))
+    return body
+
+
 def _update_client(panel_url: str, token: str, username: str, changes: Mapping[str, Any]) -> Tuple[bool, Optional[str]]:
     current, err = _fetch_client(panel_url, token, username)
     if err:
         return False, err
-    client = _extract_client(current)
+    client = _prepare_update_payload(current, username, changes)
     if not client:
         return False, "not found"
-    client.update({key: value for key, value in changes.items() if value is not None})
-    client.setdefault("email", username)
     try:
         r = _request_with_reauth(
             "POST",
@@ -529,13 +583,13 @@ def _update_client(panel_url: str, token: str, username: str, changes: Mapping[s
 def disable_remote_user(panel_url: str, token: str, username: str) -> Tuple[bool, Optional[str]]:
     """Disable a client via ``POST /panel/api/clients/update/{email}``."""
 
-    return _update_client(panel_url, token, username, {"enable": False, "enabled": False})
+    return _update_client(panel_url, token, username, {"enable": False})
 
 
 def enable_remote_user(panel_url: str, token: str, username: str) -> Tuple[bool, Optional[str]]:
     """Enable a client via ``POST /panel/api/clients/update/{email}``."""
 
-    return _update_client(panel_url, token, username, {"enable": True, "enabled": True})
+    return _update_client(panel_url, token, username, {"enable": True})
 
 
 def remove_remote_user(panel_url: str, token: str, username: str) -> Tuple[bool, Optional[str]]:

--- a/bot.py
+++ b/bot.py
@@ -4093,7 +4093,7 @@ async def handle_edit_limit(update: Update, context: ContextTypes.DEFAULT_TYPE):
     class FakeCQ:
         async def edit_message_text(self, *args, **kwargs):
             await update.message.reply_text(*args, **kwargs)
-    return await show_user_card(FakeCQ(), owner_id, uname, notice="✅ لیمیت بروزرسانی شد.")
+    return await show_user_card(FakeCQ(), context, owner_id, uname, notice="✅ لیمیت بروزرسانی شد.")
 
 async def handle_renew_days(update: Update, context: ContextTypes.DEFAULT_TYPE):
     uname = context.user_data.get("manage_username")
@@ -4111,7 +4111,7 @@ async def handle_renew_days(update: Update, context: ContextTypes.DEFAULT_TYPE):
     class FakeCQ:
         async def edit_message_text(self, *args, **kwargs):
             await update.message.reply_text(*args, **kwargs)
-    return await show_user_card(FakeCQ(), owner_id, uname, notice=f"✅ {days} روز تمدید شد.")
+    return await show_user_card(FakeCQ(), context, owner_id, uname, notice=f"✅ {days} روز تمدید شد.")
 
 # ---------- cancel ----------
 async def cancel(update: Update, context: ContextTypes.DEFAULT_TYPE):

--- a/tests/test_sanaei_modern.py
+++ b/tests/test_sanaei_modern.py
@@ -84,6 +84,79 @@ class SanaeiModernResponseTests(unittest.TestCase):
         self.assertIn("already exists", err)
         request.assert_not_called()
 
+    def test_normalise_user_object_parses_string_false_enable(self):
+        user = sanaei_modern._normalise_user_object({"email": "alice", "enable": "false"})
+
+        self.assertFalse(user["enabled"])
+        self.assertFalse(user["enable"])
+
+    def test_update_remote_user_uses_modern_update_endpoint_and_client_payload(self):
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = {"success": True, "msg": "Client updated"}
+        current = {
+            "email": "alice@example.com",
+            "id": "uuid-1",
+            "totalGB": 1024,
+            "expiryTime": 0,
+            "enable": True,
+            "inboundIds": [7],
+            "used_traffic": 100,
+            "up": 40,
+            "down": 60,
+            "links": ["vless://example"],
+        }
+
+        with patch.object(sanaei_modern, "_fetch_client", return_value=(current, None)), patch.object(
+            sanaei_modern, "_request_with_reauth", return_value=response
+        ) as request:
+            ok, err = sanaei_modern.update_remote_user(
+                "https://panel.example", "token", "alice@example.com", data_limit=2048
+            )
+
+        self.assertTrue(ok)
+        self.assertIsNone(err)
+        request.assert_called_once()
+        args = request.call_args.args
+        self.assertEqual(args[:7], ("POST", "https://panel.example", "token", "panel", "api", "clients", "update"))
+        self.assertEqual(args[7], "alice@example.com")
+        sent_json = request.call_args.kwargs["json"]
+        self.assertEqual(sent_json["email"], "alice@example.com")
+        self.assertEqual(sent_json["totalGB"], 2048)
+        self.assertEqual(sent_json["id"], "uuid-1")
+        self.assertNotIn("inboundIds", sent_json)
+        self.assertNotIn("used_traffic", sent_json)
+        self.assertNotIn("up", sent_json)
+        self.assertNotIn("down", sent_json)
+        self.assertNotIn("links", sent_json)
+
+    def test_disable_and_enable_use_update_payload_enable_field_only(self):
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = {"success": True}
+        current = {"client": {"email": "alice", "totalGB": 1024, "enabled": "false", "inboundIds": [1]}}
+
+        with patch.object(sanaei_modern, "_fetch_client", return_value=(current, None)), patch.object(
+            sanaei_modern, "_request_with_reauth", return_value=response
+        ) as request:
+            ok, err = sanaei_modern.disable_remote_user("https://panel.example", "token", "alice")
+
+        self.assertTrue(ok)
+        self.assertIsNone(err)
+        sent_json = request.call_args.kwargs["json"]
+        self.assertEqual(sent_json["enable"], False)
+        self.assertNotIn("enabled", sent_json)
+        self.assertNotIn("inboundIds", sent_json)
+
+        with patch.object(sanaei_modern, "_fetch_client", return_value=(current, None)), patch.object(
+            sanaei_modern, "_request_with_reauth", return_value=response
+        ) as request:
+            ok, err = sanaei_modern.enable_remote_user("https://panel.example", "token", "alice")
+
+        self.assertTrue(ok)
+        self.assertIsNone(err)
+        self.assertEqual(request.call_args.kwargs["json"]["enable"], True)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Motivation
- Ensure the Sanaei (modern) adapter updates client quotas and enable/disable state using the documented `/panel/api/clients/update/{email}` shape rather than sending response-only fields. 
- Treat string boolean values returned by the panel (e.g. `"false"`) as boolean false so UI/state decisions are correct. 
- Restore the Telegram conversation `context` flow so the user card renders properly after editing limit or renewing a user.

### Description
- Add `_coerce_bool` and use it when normalising modern client `enable`/`enabled` values so string false-like values are handled correctly. 
- Introduce `_MODERN_CLIENT_UPDATE_DROP_FIELDS` and `_prepare_update_payload` to strip traffic/links/inbound fields from the client object and build a clean client JSON body for `POST /panel/api/clients/update/{email}`. 
- Make `disable_remote_user`/`enable_remote_user` send only the documented `enable` field to the update endpoint. 
- Fix bot handlers to pass the conversation `context` into `show_user_card` after editing limit or renewing so the card renders correctly. 
- Add unit tests to `tests/test_sanaei_modern.py` covering string-boolean normalisation, the prepared update payload (ensuring dropped fields), and enable/disable behavior.

### Testing
- Ran `python -m compileall apis/sanaei_modern.py bot.py tests/test_sanaei_modern.py` successfully. 
- Ran `pytest -q` with the Sanaei modern test suite and new tests: all tests passed (6 passed, 8 subtests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24b0bfc72c8323989461b1fe726e37)