### PR TITLE
Fix show_user_card argument order in edit/renew handlers

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -4093,7 +4093,7 @@ async def handle_edit_limit(update: Update, context: ContextTypes.DEFAULT_TYPE):
     class FakeCQ:
         async def edit_message_text(self, *args, **kwargs):
             await update.message.reply_text(*args, **kwargs)
-    return await show_user_card(FakeCQ(), context, owner_id, uname, notice="✅ لیمیت بروزرسانی شد.")
+    return await show_user_card(FakeCQ(), owner_id, uname, notice="✅ لیمیت بروزرسانی شد.")
 
 async def handle_renew_days(update: Update, context: ContextTypes.DEFAULT_TYPE):
     uname = context.user_data.get("manage_username")
@@ -4111,7 +4111,7 @@ async def handle_renew_days(update: Update, context: ContextTypes.DEFAULT_TYPE):
     class FakeCQ:
         async def edit_message_text(self, *args, **kwargs):
             await update.message.reply_text(*args, **kwargs)
-    return await show_user_card(FakeCQ(), context, owner_id, uname, notice=f"✅ {days} روز تمدید شد.")
+    return await show_user_card(FakeCQ(), owner_id, uname, notice=f"✅ {days} روز تمدید شد.")
 
 # ---------- cancel ----------
 async def cancel(update: Update, context: ContextTypes.DEFAULT_TYPE):


### PR DESCRIPTION
### Motivation
- Calling `show_user_card` with the Telegram `context` as an extra positional argument caused a `TypeError` when refreshing the user card after editing limits or renewing days because the function signature is `show_user_card(q, owner_id, uname, notice)`.

### Description
- In `bot.py` updated `handle_edit_limit` to call `show_user_card(FakeCQ(), owner_id, uname, notice=...)` instead of passing `context` as a positional argument.
- Applied the same fix to `handle_renew_days` so it also calls `show_user_card(FakeCQ(), owner_id, uname, notice=...)` with the correct argument order.
- The small change keeps the local `FakeCQ` shim used to forward `edit_message_text` to `update.message.reply_text`.

### Testing
- Ran syntax check with `python -m py_compile bot.py apis/sanaei_modern.py`, which succeeded.
- Ran unit tests with `python -m unittest tests.test_sanaei_modern`, which executed 6 tests and reported `OK`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24b2b9af688323bab48a06afd3d3de)