### PR TITLE
Fix modern Sanaei client update payload ids

### DIFF
--- a/apis/sanaei_modern.py
+++ b/apis/sanaei_modern.py
@@ -545,6 +545,13 @@ def _prepare_update_payload(current: Any, username: str, changes: Mapping[str, A
         body["email"] = _first_present(client, "email", "username") or username
     if body.get("enable") is not None:
         body["enable"] = _coerce_bool(body.get("enable"))
+    # Modern 3x-ui's Client.id field is a string (UUID/protocol secret).
+    # Some panel responses also include a numeric database row id named ``id``;
+    # sending that number back to /clients/update/{email} makes Go reject the
+    # JSON before applying traffic-limit or enable changes.  Keep string ids
+    # intact and stringify numeric ids so update/disable calls remain accepted.
+    if body.get("id") is not None and not isinstance(body.get("id"), str):
+        body["id"] = str(body["id"])
     return body
 
 

--- a/tests/test_sanaei_modern.py
+++ b/tests/test_sanaei_modern.py
@@ -130,6 +130,27 @@ class SanaeiModernResponseTests(unittest.TestCase):
         self.assertNotIn("down", sent_json)
         self.assertNotIn("links", sent_json)
 
+    def test_update_payload_stringifies_numeric_client_id(self):
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = {"success": True}
+        current = {
+            "email": "alice",
+            "id": 123,
+            "totalGB": 1024,
+            "expiryTime": 0,
+            "enable": True,
+        }
+
+        with patch.object(sanaei_modern, "_fetch_client", return_value=(current, None)), patch.object(
+            sanaei_modern, "_request_with_reauth", return_value=response
+        ) as request:
+            ok, err = sanaei_modern.update_remote_user("https://panel.example", "token", "alice", data_limit=2048)
+
+        self.assertTrue(ok)
+        self.assertIsNone(err)
+        self.assertEqual(request.call_args.kwargs["json"]["id"], "123")
+
     def test_disable_and_enable_use_update_payload_enable_field_only(self):
         response = Mock()
         response.status_code = 200


### PR DESCRIPTION
### Motivation
- Modern 3x-ui panels expose a `Client.id` as a string (UUID/protocol secret), but some panel responses include a numeric `id` that causes Go to reject `/panel/api/clients/update/{email}` JSON, breaking traffic-limit edits and disable/enable flows. 

### Description
- Convert numeric client `id` values to strings in `_prepare_update_payload` so `/panel/api/clients/update/{email}` always receives a string `id` and string `id`s are preserved. 
- Keep the existing sanitisation that drops non-update fields and normalises the `enable` flag. 
- Added a regression test `test_update_payload_stringifies_numeric_client_id` to `tests/test_sanaei_modern.py` that verifies numeric `id` is stringified before the update request. 
- Changes applied to `apis/sanaei_modern.py` and `tests/test_sanaei_modern.py`.

### Testing
- Ran `python -m unittest tests/test_sanaei_modern.py` and all tests passed (`7 tests` succeeded). 
- Ran `pytest tests/test_sanaei_modern.py` and the test suite passed (`7 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24b43150fc8323b6acf497dae784f4)