### PR TITLE
Drop `id`/`uuid` from modern client update payloads

### DIFF
--- a/apis/sanaei_modern.py
+++ b/apis/sanaei_modern.py
@@ -528,6 +528,7 @@ _MODERN_CLIENT_UPDATE_DROP_FIELDS = {
     "expiry_time",
     "expire",
     "expireTime",
+    "id",
     "uuid",
     "username",
 }
@@ -545,13 +546,12 @@ def _prepare_update_payload(current: Any, username: str, changes: Mapping[str, A
         body["email"] = _first_present(client, "email", "username") or username
     if body.get("enable") is not None:
         body["enable"] = _coerce_bool(body.get("enable"))
-    # Modern 3x-ui's Client.id field is a string (UUID/protocol secret).
-    # Some panel responses also include a numeric database row id named ``id``;
-    # sending that number back to /clients/update/{email} makes Go reject the
-    # JSON before applying traffic-limit or enable changes.  Keep string ids
-    # intact and stringify numeric ids so update/disable calls remain accepted.
-    if body.get("id") is not None and not isinstance(body.get("id"), str):
-        body["id"] = str(body["id"])
+    # Never send id/uuid on modern update requests.  The endpoint identifies
+    # the existing client by the email path parameter, and echoing any id value
+    # can mutate the protocol UUID/secret (for example replacing it with a
+    # numeric database row id such as "12").
+    body.pop("id", None)
+    body.pop("uuid", None)
     return body
 
 

--- a/tests/test_sanaei_modern.py
+++ b/tests/test_sanaei_modern.py
@@ -123,23 +123,26 @@ class SanaeiModernResponseTests(unittest.TestCase):
         sent_json = request.call_args.kwargs["json"]
         self.assertEqual(sent_json["email"], "alice@example.com")
         self.assertEqual(sent_json["totalGB"], 2048)
-        self.assertEqual(sent_json["id"], "uuid-1")
+        self.assertNotIn("id", sent_json)
+        self.assertNotIn("uuid", sent_json)
         self.assertNotIn("inboundIds", sent_json)
         self.assertNotIn("used_traffic", sent_json)
         self.assertNotIn("up", sent_json)
         self.assertNotIn("down", sent_json)
         self.assertNotIn("links", sent_json)
 
-    def test_update_payload_stringifies_numeric_client_id(self):
+    def test_update_payload_never_sends_uuid_or_id_fields(self):
         response = Mock()
         response.status_code = 200
         response.json.return_value = {"success": True}
         current = {
             "email": "alice",
-            "id": 123,
+            "id": 12,
+            "uuid": "550e8400-e29b-41d4-a716-446655440000",
             "totalGB": 1024,
             "expiryTime": 0,
             "enable": True,
+            "links": ["vless://550e8400-e29b-41d4-a716-446655440000@example:443?security=tls#alice"],
         }
 
         with patch.object(sanaei_modern, "_fetch_client", return_value=(current, None)), patch.object(
@@ -149,7 +152,39 @@ class SanaeiModernResponseTests(unittest.TestCase):
 
         self.assertTrue(ok)
         self.assertIsNone(err)
-        self.assertEqual(request.call_args.kwargs["json"]["id"], "123")
+        sent_json = request.call_args.kwargs["json"]
+        self.assertNotIn("id", sent_json)
+        self.assertNotIn("uuid", sent_json)
+
+    def test_disable_and_enable_drop_id_even_when_current_id_is_string_uuid(self):
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = {"success": True}
+        current = {
+            "email": "alice",
+            "id": "550e8400-e29b-41d4-a716-446655440000",
+            "totalGB": 1024,
+            "expiryTime": 0,
+            "enable": True,
+        }
+
+        with patch.object(sanaei_modern, "_fetch_client", return_value=(current, None)), patch.object(
+            sanaei_modern, "_request_with_reauth", return_value=response
+        ) as request:
+            ok, err = sanaei_modern.disable_remote_user("https://panel.example", "token", "alice")
+
+        self.assertTrue(ok)
+        self.assertIsNone(err)
+        self.assertNotIn("id", request.call_args.kwargs["json"])
+
+        with patch.object(sanaei_modern, "_fetch_client", return_value=(current, None)), patch.object(
+            sanaei_modern, "_request_with_reauth", return_value=response
+        ) as request:
+            ok, err = sanaei_modern.enable_remote_user("https://panel.example", "token", "alice")
+
+        self.assertTrue(ok)
+        self.assertIsNone(err)
+        self.assertNotIn("id", request.call_args.kwargs["json"])
 
     def test_disable_and_enable_use_update_payload_enable_field_only(self):
         response = Mock()


### PR DESCRIPTION
### Motivation

- The panel update endpoint identifies clients by the email path parameter and echoing an `id` or `uuid` in the request can mutate the protocol UUID/secret or cause server-side JSON rejection. 

### Description

- Added `"id"` to `_MODERN_CLIENT_UPDATE_DROP_FIELDS` and removed the prior numeric-stringification logic to ensure `id`/`uuid` are not sent in update payloads. 
- Updated `_prepare_update_payload` to `pop` both `id` and `uuid` from the outgoing `body` so the endpoint is not given any id values. 
- Adjusted and renamed tests in `tests/test_sanaei_modern.py` to assert that `id` and `uuid` are not present in update requests and added a test to ensure disable/enable flows also drop `id`. 

### Testing

- Ran the modified unit tests in `tests/test_sanaei_modern.py`, including `test_update_payload_never_sends_uuid_or_id_fields` and `test_disable_and_enable_drop_id_even_when_current_id_is_string_uuid`, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24b64dd7448323a8074c11dc0eac63)