### PR TITLE
Fix modern Sanaei update UUID handling

### DIFF
--- a/apis/sanaei_modern.py
+++ b/apis/sanaei_modern.py
@@ -528,6 +528,10 @@ _MODERN_CLIENT_UPDATE_DROP_FIELDS = {
     "expiry_time",
     "expire",
     "expireTime",
+    # The row/database id and raw UUID field are intentionally dropped from the
+    # copied client payload below.  Modern Sanaei update requests must send the
+    # protocol UUID as the payload's ``id`` field, so _prepare_update_payload
+    # derives that value explicitly from the freshly fetched client UUID.
     "id",
     "uuid",
     "username",
@@ -538,6 +542,9 @@ def _prepare_update_payload(current: Any, username: str, changes: Mapping[str, A
     client = _extract_client(current)
     if not client:
         return {}
+    client_uuid = client.get("uuid")
+    if client_uuid is None or str(client_uuid).strip() == "":
+        return {}
     body = {key: value for key, value in client.items() if key not in _MODERN_CLIENT_UPDATE_DROP_FIELDS}
     if client.get("enable") is None and client.get("enabled") is not None:
         body["enable"] = _coerce_bool(client.get("enabled"))
@@ -546,11 +553,11 @@ def _prepare_update_payload(current: Any, username: str, changes: Mapping[str, A
         body["email"] = _first_present(client, "email", "username") or username
     if body.get("enable") is not None:
         body["enable"] = _coerce_bool(body.get("enable"))
-    # Never send id/uuid on modern update requests.  The endpoint identifies
-    # the existing client by the email path parameter, and echoing any id value
-    # can mutate the protocol UUID/secret (for example replacing it with a
-    # numeric database row id such as "12").
-    body.pop("id", None)
+    # Modern Sanaei uses the path email as the current username, but the update
+    # body must also include the client's existing protocol UUID as ``id``.
+    # Omitting it can make the panel generate a new UUID and break existing
+    # subscription links/client configs.  Do not reuse numeric database row IDs.
+    body["id"] = str(client_uuid).strip()
     body.pop("uuid", None)
     return body
 
@@ -559,9 +566,12 @@ def _update_client(panel_url: str, token: str, username: str, changes: Mapping[s
     current, err = _fetch_client(panel_url, token, username)
     if err:
         return False, err
+    current_client = _extract_client(current)
+    if not current_client:
+        return False, "not found"
     client = _prepare_update_payload(current, username, changes)
     if not client:
-        return False, "not found"
+        return False, "client uuid not found"
     try:
         r = _request_with_reauth(
             "POST",

--- a/tests/test_sanaei_modern.py
+++ b/tests/test_sanaei_modern.py
@@ -96,7 +96,8 @@ class SanaeiModernResponseTests(unittest.TestCase):
         response.json.return_value = {"success": True, "msg": "Client updated"}
         current = {
             "email": "alice@example.com",
-            "id": "uuid-1",
+            "id": 12,
+            "uuid": "uuid-1",
             "totalGB": 1024,
             "expiryTime": 0,
             "enable": True,
@@ -123,7 +124,7 @@ class SanaeiModernResponseTests(unittest.TestCase):
         sent_json = request.call_args.kwargs["json"]
         self.assertEqual(sent_json["email"], "alice@example.com")
         self.assertEqual(sent_json["totalGB"], 2048)
-        self.assertNotIn("id", sent_json)
+        self.assertEqual(sent_json["id"], "uuid-1")
         self.assertNotIn("uuid", sent_json)
         self.assertNotIn("inboundIds", sent_json)
         self.assertNotIn("used_traffic", sent_json)
@@ -131,7 +132,7 @@ class SanaeiModernResponseTests(unittest.TestCase):
         self.assertNotIn("down", sent_json)
         self.assertNotIn("links", sent_json)
 
-    def test_update_payload_never_sends_uuid_or_id_fields(self):
+    def test_update_payload_sends_fetched_uuid_as_id_field(self):
         response = Mock()
         response.status_code = 200
         response.json.return_value = {"success": True}
@@ -153,16 +154,35 @@ class SanaeiModernResponseTests(unittest.TestCase):
         self.assertTrue(ok)
         self.assertIsNone(err)
         sent_json = request.call_args.kwargs["json"]
-        self.assertNotIn("id", sent_json)
+        self.assertEqual(sent_json["id"], "550e8400-e29b-41d4-a716-446655440000")
         self.assertNotIn("uuid", sent_json)
 
-    def test_disable_and_enable_drop_id_even_when_current_id_is_string_uuid(self):
+    def test_update_refuses_to_post_without_fetched_uuid(self):
+        current = {
+            "email": "alice",
+            "id": 12,
+            "totalGB": 1024,
+            "expiryTime": 0,
+            "enable": True,
+        }
+
+        with patch.object(sanaei_modern, "_fetch_client", return_value=(current, None)), patch.object(
+            sanaei_modern, "_request_with_reauth"
+        ) as request:
+            ok, err = sanaei_modern.update_remote_user("https://panel.example", "token", "alice", data_limit=2048)
+
+        self.assertFalse(ok)
+        self.assertEqual(err, "client uuid not found")
+        request.assert_not_called()
+
+    def test_disable_and_enable_include_current_uuid_as_id(self):
         response = Mock()
         response.status_code = 200
         response.json.return_value = {"success": True}
         current = {
             "email": "alice",
-            "id": "550e8400-e29b-41d4-a716-446655440000",
+            "id": 12,
+            "uuid": "550e8400-e29b-41d4-a716-446655440000",
             "totalGB": 1024,
             "expiryTime": 0,
             "enable": True,
@@ -175,7 +195,7 @@ class SanaeiModernResponseTests(unittest.TestCase):
 
         self.assertTrue(ok)
         self.assertIsNone(err)
-        self.assertNotIn("id", request.call_args.kwargs["json"])
+        self.assertEqual(request.call_args.kwargs["json"]["id"], "550e8400-e29b-41d4-a716-446655440000")
 
         with patch.object(sanaei_modern, "_fetch_client", return_value=(current, None)), patch.object(
             sanaei_modern, "_request_with_reauth", return_value=response
@@ -184,13 +204,21 @@ class SanaeiModernResponseTests(unittest.TestCase):
 
         self.assertTrue(ok)
         self.assertIsNone(err)
-        self.assertNotIn("id", request.call_args.kwargs["json"])
+        self.assertEqual(request.call_args.kwargs["json"]["id"], "550e8400-e29b-41d4-a716-446655440000")
 
     def test_disable_and_enable_use_update_payload_enable_field_only(self):
         response = Mock()
         response.status_code = 200
         response.json.return_value = {"success": True}
-        current = {"client": {"email": "alice", "totalGB": 1024, "enabled": "false", "inboundIds": [1]}}
+        current = {
+            "client": {
+                "email": "alice",
+                "uuid": "550e8400-e29b-41d4-a716-446655440000",
+                "totalGB": 1024,
+                "enabled": "false",
+                "inboundIds": [1],
+            }
+        }
 
         with patch.object(sanaei_modern, "_fetch_client", return_value=(current, None)), patch.object(
             sanaei_modern, "_request_with_reauth", return_value=response
@@ -203,6 +231,7 @@ class SanaeiModernResponseTests(unittest.TestCase):
         self.assertEqual(sent_json["enable"], False)
         self.assertNotIn("enabled", sent_json)
         self.assertNotIn("inboundIds", sent_json)
+        self.assertEqual(sent_json["id"], "550e8400-e29b-41d4-a716-446655440000")
 
         with patch.object(sanaei_modern, "_fetch_client", return_value=(current, None)), patch.object(
             sanaei_modern, "_request_with_reauth", return_value=response


### PR DESCRIPTION
### Motivation

- Modern Sanaei's `/panel/api/clients/update/{email}` requires the client's protocol UUID in the update payload `id` field to avoid the panel generating a new UUID and breaking subscriptions; previously the adapter stripped `id/uuid` and could unintentionally cause UUID rotation.

### Description

- Ensure the freshly fetched client `uuid` is required and copied into the outgoing update payload as `id` in `_prepare_update_payload` in `apis/sanaei_modern.py`.
- Add a guard to refuse posting updates when the fetched client record lacks a usable `uuid` so updates are not sent with an invalid/missing identifier. 
- Preserve the existing username in the `email` field and continue to drop database row id/`uuid` fields from copied client data except for inserting the protocol UUID into `id`.
- Update unit tests in `tests/test_sanaei_modern.py` to assert the adapter: includes fetched `uuid` as `id` for quota/enable/disable flows, omits stale fields, and refuses to post when no `uuid` is present.

### Testing

- Ran `python -m pytest tests/test_sanaei_modern.py -q` and `python -m pytest -q`; all relevant tests passed (tests for modern Sanaei adapter passed).
- Ran `git diff --check` to ensure no whitespace or diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a283704ed08832e977b1b4422a23030)