### PR TITLE
Prefer local expiry when building subscription page user (fix stale remote expiry)

### DIFF
--- a/api/subscription_aggregator/flask_app.py
+++ b/api/subscription_aggregator/flask_app.py
@@ -877,15 +877,12 @@ def build_user(local_username, app_key, lu, remote=None):
     manual_disabled = bool(lu.get("manual_disabled")) if lu else False
     if remote:
         enabled = remote.get("enabled", True)
-        expire_raw = (
-            remote.get("expire_date")
-            or remote.get("expire")
-            or remote.get("expiryTime")
-            or remote.get("expiry_time")
-            or remote.get("expire_at")
-            or ""
-        )
-    if not expire_raw and lu:
+
+    # The subscription page is the customer-facing view of the local plan.
+    # Renewals update local_users.expire_at first and panel updates can lag or
+    # fail independently, so prefer the local expiry over stale remote metadata
+    # when calculating remaining days and the Jalali expiration date.
+    if lu:
         exp_l = lu.get("expire_at")
         if exp_l:
             try:
@@ -895,6 +892,16 @@ def build_user(local_username, app_key, lu, remote=None):
                     expire_raw = str(int(datetime.fromisoformat(str(exp_l)).timestamp()))
             except Exception:
                 expire_raw = ""
+
+    if not expire_raw and remote:
+        expire_raw = (
+            remote.get("expire_date")
+            or remote.get("expire")
+            or remote.get("expiryTime")
+            or remote.get("expiry_time")
+            or remote.get("expire_at")
+            or ""
+        )
     data_limit_reached = bool(limit > 0 and used >= limit)
     expired = False
     if manual_disabled:


### PR DESCRIPTION
### Motivation
- The subscription subpage used remote panel metadata when computing remaining days and the Jalali expiration date, which could remain stale after local renewals that update `local_users.expire_at` first.
- Ensure the customer-facing view reflects the authoritative local expiry so UX shows correct remaining days immediately after adding days.

### Description
- Updated `build_user` in `api/subscription_aggregator/flask_app.py` to prefer the local `lu["expire_at"]` value when deriving `expire_raw` and only fall back to remote panel fields if the local expiry is absent.
- Added an explanatory comment describing why the local expiry is preferred (renewals update local state first and panel updates may lag or fail).
- Kept the rest of `build_user` behavior unchanged, including parsing `expire_raw` and computing `expired`/`data_limit_reached`.

### Testing
- Ran `python -m py_compile api/subscription_aggregator/flask_app.py` which succeeded. 
- Ran `git diff --check` which reported no whitespace or diff issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4780d579e883308d5e360f14afcb3e)