### PR TITLE
Fix modern Sanaei renewal payload

### DIFF
--- a/apis/sanaei_modern.py
+++ b/apis/sanaei_modern.py
@@ -528,10 +528,10 @@ _MODERN_CLIENT_UPDATE_DROP_FIELDS = {
     "expiry_time",
     "expire",
     "expireTime",
-    # The row/database id and raw UUID field are intentionally dropped from the
-    # copied client payload below.  Modern Sanaei update requests must send the
-    # protocol UUID as the payload's ``id`` field, so _prepare_update_payload
-    # derives that value explicitly from the freshly fetched client UUID.
+    # IDs returned by lookup endpoints are intentionally dropped.  The modern
+    # /panel/api/clients/update/{email} endpoint is documented to receive only
+    # the JSON client fields the caller wants to keep; including row IDs or
+    # protocol UUID aliases can make expiry-only renewals fail on newer panels.
     "id",
     "uuid",
     "username",
@@ -542,9 +542,6 @@ def _prepare_update_payload(current: Any, username: str, changes: Mapping[str, A
     client = _extract_client(current)
     if not client:
         return {}
-    client_uuid = client.get("uuid")
-    if client_uuid is None or str(client_uuid).strip() == "":
-        return {}
     body = {key: value for key, value in client.items() if key not in _MODERN_CLIENT_UPDATE_DROP_FIELDS}
     if client.get("enable") is None and client.get("enabled") is not None:
         body["enable"] = _coerce_bool(client.get("enabled"))
@@ -553,12 +550,11 @@ def _prepare_update_payload(current: Any, username: str, changes: Mapping[str, A
         body["email"] = _first_present(client, "email", "username") or username
     if body.get("enable") is not None:
         body["enable"] = _coerce_bool(body.get("enable"))
-    # Modern Sanaei uses the path email as the current username, but the update
-    # body must also include the client's existing protocol UUID as ``id``.
-    # Omitting it can make the panel generate a new UUID and break existing
-    # subscription links/client configs.  Do not reuse numeric database row IDs.
-    body["id"] = str(client_uuid).strip()
+    # Modern Sanaei uses the path email as the current username.  Its documented
+    # update body is the client payload (for example email/totalGB/expiryTime/
+    # tgId/enable) and not an inbound wrapper or identifier object.
     body.pop("uuid", None)
+    body.pop("id", None)
     return body
 
 
@@ -571,7 +567,7 @@ def _update_client(panel_url: str, token: str, username: str, changes: Mapping[s
         return False, "not found"
     client = _prepare_update_payload(current, username, changes)
     if not client:
-        return False, "client uuid not found"
+        return False, "client payload not found"
     try:
         r = _request_with_reauth(
             "POST",

--- a/tests/test_sanaei_modern.py
+++ b/tests/test_sanaei_modern.py
@@ -124,7 +124,7 @@ class SanaeiModernResponseTests(unittest.TestCase):
         sent_json = request.call_args.kwargs["json"]
         self.assertEqual(sent_json["email"], "alice@example.com")
         self.assertEqual(sent_json["totalGB"], 2048)
-        self.assertEqual(sent_json["id"], "uuid-1")
+        self.assertNotIn("id", sent_json)
         self.assertNotIn("uuid", sent_json)
         self.assertNotIn("inboundIds", sent_json)
         self.assertNotIn("used_traffic", sent_json)
@@ -132,18 +132,17 @@ class SanaeiModernResponseTests(unittest.TestCase):
         self.assertNotIn("down", sent_json)
         self.assertNotIn("links", sent_json)
 
-    def test_update_payload_sends_fetched_uuid_as_id_field(self):
+    def test_update_payload_drops_identifier_fields_from_modern_request(self):
         response = Mock()
         response.status_code = 200
         response.json.return_value = {"success": True}
         current = {
             "email": "alice",
-            "id": 12,
+            "id": "550e8400-e29b-41d4-a716-446655440000",
             "uuid": "550e8400-e29b-41d4-a716-446655440000",
             "totalGB": 1024,
             "expiryTime": 0,
             "enable": True,
-            "links": ["vless://550e8400-e29b-41d4-a716-446655440000@example:443?security=tls#alice"],
         }
 
         with patch.object(sanaei_modern, "_fetch_client", return_value=(current, None)), patch.object(
@@ -154,10 +153,13 @@ class SanaeiModernResponseTests(unittest.TestCase):
         self.assertTrue(ok)
         self.assertIsNone(err)
         sent_json = request.call_args.kwargs["json"]
-        self.assertEqual(sent_json["id"], "550e8400-e29b-41d4-a716-446655440000")
+        self.assertNotIn("id", sent_json)
         self.assertNotIn("uuid", sent_json)
 
-    def test_update_refuses_to_post_without_fetched_uuid(self):
+    def test_update_allows_expiry_renewal_without_uuid_and_sends_milliseconds(self):
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = {"success": True}
         current = {
             "email": "alice",
             "id": 12,
@@ -167,15 +169,19 @@ class SanaeiModernResponseTests(unittest.TestCase):
         }
 
         with patch.object(sanaei_modern, "_fetch_client", return_value=(current, None)), patch.object(
-            sanaei_modern, "_request_with_reauth"
+            sanaei_modern, "_request_with_reauth", return_value=response
         ) as request:
-            ok, err = sanaei_modern.update_remote_user("https://panel.example", "token", "alice", data_limit=2048)
+            ok, err = sanaei_modern.update_remote_user("https://panel.example", "token", "alice", expire=1767225600)
 
-        self.assertFalse(ok)
-        self.assertEqual(err, "client uuid not found")
-        request.assert_not_called()
+        self.assertTrue(ok)
+        self.assertIsNone(err)
+        sent_json = request.call_args.kwargs["json"]
+        self.assertEqual(sent_json["expiryTime"], 1767225600000)
+        self.assertEqual(sent_json["email"], "alice")
+        self.assertNotIn("id", sent_json)
+        self.assertNotIn("uuid", sent_json)
 
-    def test_disable_and_enable_include_current_uuid_as_id(self):
+    def test_disable_and_enable_drop_current_uuid_from_payload(self):
         response = Mock()
         response.status_code = 200
         response.json.return_value = {"success": True}
@@ -195,7 +201,7 @@ class SanaeiModernResponseTests(unittest.TestCase):
 
         self.assertTrue(ok)
         self.assertIsNone(err)
-        self.assertEqual(request.call_args.kwargs["json"]["id"], "550e8400-e29b-41d4-a716-446655440000")
+        self.assertNotIn("id", request.call_args.kwargs["json"])
 
         with patch.object(sanaei_modern, "_fetch_client", return_value=(current, None)), patch.object(
             sanaei_modern, "_request_with_reauth", return_value=response
@@ -204,7 +210,7 @@ class SanaeiModernResponseTests(unittest.TestCase):
 
         self.assertTrue(ok)
         self.assertIsNone(err)
-        self.assertEqual(request.call_args.kwargs["json"]["id"], "550e8400-e29b-41d4-a716-446655440000")
+        self.assertNotIn("id", request.call_args.kwargs["json"])
 
     def test_disable_and_enable_use_update_payload_enable_field_only(self):
         response = Mock()
@@ -231,7 +237,7 @@ class SanaeiModernResponseTests(unittest.TestCase):
         self.assertEqual(sent_json["enable"], False)
         self.assertNotIn("enabled", sent_json)
         self.assertNotIn("inboundIds", sent_json)
-        self.assertEqual(sent_json["id"], "550e8400-e29b-41d4-a716-446655440000")
+        self.assertNotIn("id", sent_json)
 
         with patch.object(sanaei_modern, "_fetch_client", return_value=(current, None)), patch.object(
             sanaei_modern, "_request_with_reauth", return_value=response


### PR DESCRIPTION
### Motivation
- Modern Sanaei's `/panel/api/clients/update/{email}` endpoint expects the JSON client payload (email/totalGB/expiryTime/tgId/enable) and including lookup identifier fields breaks expiry-only renewals for some panels, causing renew-days behavior to fail.

### Description
- Stop enforcing a fetched `uuid` for modern Sanaei updates so expiry-only renewals can proceed when the panel response lacks a `uuid` field.
- Strip lookup identifier fields (`id`, `uuid`) from the prepared update body so requests send only the documented client fields for `/panel/api/clients/update/{email}`.
- Clarify the `_MODERN_CLIENT_UPDATE_DROP_FIELDS` comment and change the error message from `client uuid not found` to `client payload not found` when no usable client payload is available.
- Update `tests/test_sanaei_modern.py` to assert that identifier fields are not sent and to add a test ensuring expiry renewals send `expiryTime` in milliseconds.

### Testing
- Ran `python -m unittest tests/test_sanaei_modern.py` and all tests passed (9 tests, OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4782557f00832992ea2839c3caf1b8)