### PR TITLE
Use bulkAdjust addDays for modern Sanaei renewals

### DIFF
--- a/apis/sanaei_modern.py
+++ b/apis/sanaei_modern.py
@@ -651,6 +651,38 @@ def reset_remote_user_usage(panel_url: str, token: str, username: str) -> Tuple[
         return False, str(e)[:200]
 
 
+def renew_remote_user(panel_url: str, token: str, username: str, add_days: int) -> Tuple[bool, Optional[str]]:
+    """Extend one client via ``POST /panel/api/clients/bulkAdjust``.
+
+    The modern Sanaei API exposes day-based renewal as ``bulkAdjust`` with
+    ``addDays``.  Use that endpoint for renewals instead of rewriting the full
+    client through ``/clients/update/{email}``, which is intended for absolute
+    client-field replacement.
+    """
+
+    try:
+        r = _request_with_reauth(
+            "POST",
+            panel_url,
+            token,
+            "panel",
+            "api",
+            "clients",
+            "bulkAdjust",
+            json={"emails": [username], "addDays": int(add_days)},
+            headers={"Content-Type": "application/json"},
+            timeout=20,
+        )
+        if r.status_code != 200:
+            return False, _response_error(r, 200)
+        data = _json_or_empty(r)
+        if not _panel_success(data):
+            return False, str(data.get("msg") or "request failed")[:200]
+        return True, None
+    except Exception as e:  # pragma: no cover - network errors
+        return False, str(e)[:200]
+
+
 def update_remote_user(
     panel_url: str,
     token: str,

--- a/bot.py
+++ b/bot.py
@@ -1365,9 +1365,13 @@ def renew_user(owner_id: int, username: str, add_days: int):
         api = get_api(r.get("panel_type"), r.get("sanaei_api_version"))
         remotes = remote_names_for_panel(r, r["remote_username"])
         for rn in remotes:
-            ok, err = api.update_remote_user(
-                r["panel_url"], r["access_token"], rn, expire=expire_ts
-            )
+            renew_remote = getattr(api, "renew_remote_user", None)
+            if callable(renew_remote):
+                ok, err = renew_remote(r["panel_url"], r["access_token"], rn, add_days)
+            else:
+                ok, err = api.update_remote_user(
+                    r["panel_url"], r["access_token"], rn, expire=expire_ts
+                )
             if not ok:
                 log.warning("remote renew failed on %s: %s", r["panel_url"], err)
             if should_enable:

--- a/tests/test_sanaei_modern.py
+++ b/tests/test_sanaei_modern.py
@@ -243,5 +243,21 @@ class SanaeiModernResponseTests(unittest.TestCase):
         self.assertEqual(request.call_args.kwargs["json"]["enable"], True)
 
 
+class SanaeiModernRenewTests(unittest.TestCase):
+    def test_renew_remote_user_uses_bulk_adjust_add_days(self):
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = {"success": True, "obj": {"adjusted": 1}}
+
+        with patch.object(sanaei_modern, "_request_with_reauth", return_value=response) as request:
+            ok, err = sanaei_modern.renew_remote_user("https://panel.example", "token", "alice", 30)
+
+        self.assertTrue(ok)
+        self.assertIsNone(err)
+        args = request.call_args.args
+        self.assertEqual(args[:7], ("POST", "https://panel.example", "token", "panel", "api", "clients", "bulkAdjust"))
+        self.assertEqual(request.call_args.kwargs["json"], {"emails": ["alice"], "addDays": 30})
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Motivation
- Modern Sanaei panels expose day-based renewals via the documented `/panel/api/clients/bulkAdjust` endpoint with `addDays`, so renew-by-days should call that instead of rewriting the full client payload through the update endpoint. 
- The existing flow attempted to update absolute expiry on modern Sanaei, which can generate new UUIDs or otherwise mis-handle day-based renews.

### Description
- Add `renew_remote_user` to `apis/sanaei_modern.py` which issues `POST /panel/api/clients/bulkAdjust` with JSON `{"emails": [username], "addDays": <n>}` and validates the response. 
- Change the central renew flow in `bot.py` to prefer a panel-specific `renew_remote_user` helper when available and fall back to the existing `update_remote_user` expiry behavior for adapters that lack it. 
- Add `tests/test_sanaei_modern.py` unit test `SanaeiModernRenewTests` to verify `renew_remote_user` calls `bulkAdjust` with the expected payload.

### Testing
- Ran the unit tests with `python -m unittest tests/test_sanaei_modern.py`, which passed (`OK`).
- Verified the modified modules compile with `python -m py_compile apis/sanaei_modern.py bot.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4785275c0083299c03873fec9f5eef)