### PR TITLE
Modern Sanaei: add-days renewal via `bulkAdjust`

### DIFF
--- a/apis/sanaei_modern.py
+++ b/apis/sanaei_modern.py
@@ -651,6 +651,38 @@ def reset_remote_user_usage(panel_url: str, token: str, username: str) -> Tuple[
         return False, str(e)[:200]
 
 
+def renew_remote_user(
+    panel_url: str,
+    token: str,
+    username: str,
+    add_days: int,
+) -> Tuple[bool, Optional[str]]:
+    """Add days to a modern Sanaei client via the documented bulkAdjust endpoint."""
+
+    try:
+        r = _request_with_reauth(
+            "POST",
+            panel_url,
+            token,
+            "panel",
+            "api",
+            "clients",
+            "bulkAdjust",
+            json={"emails": [username], "addDays": int(add_days)},
+            headers={"Content-Type": "application/json"},
+            timeout=20,
+        )
+        if r.status_code != 200:
+            return False, _response_error(r, 200)
+        data = _json_or_empty(r)
+        if not _panel_success(data):
+            return False, str(data.get("msg") or "request failed")[:200]
+        _links_cache.pop((panel_url, token, username), None)
+        return True, None
+    except Exception as e:  # pragma: no cover - network errors
+        return False, str(e)[:200]
+
+
 def update_remote_user(
     panel_url: str,
     token: str,

--- a/bot.py
+++ b/bot.py
@@ -1365,9 +1365,15 @@ def renew_user(owner_id: int, username: str, add_days: int):
         api = get_api(r.get("panel_type"), r.get("sanaei_api_version"))
         remotes = remote_names_for_panel(r, r["remote_username"])
         for rn in remotes:
-            ok, err = api.update_remote_user(
-                r["panel_url"], r["access_token"], rn, expire=expire_ts
-            )
+            renew_remote_user = getattr(api, "renew_remote_user", None)
+            if callable(renew_remote_user):
+                ok, err = renew_remote_user(
+                    r["panel_url"], r["access_token"], rn, add_days
+                )
+            else:
+                ok, err = api.update_remote_user(
+                    r["panel_url"], r["access_token"], rn, expire=expire_ts
+                )
             if not ok:
                 log.warning("remote renew failed on %s: %s", r["panel_url"], err)
             if should_enable:

--- a/tests/test_sanaei_modern.py
+++ b/tests/test_sanaei_modern.py
@@ -132,6 +132,22 @@ class SanaeiModernResponseTests(unittest.TestCase):
         self.assertNotIn("down", sent_json)
         self.assertNotIn("links", sent_json)
 
+    def test_renew_remote_user_uses_bulk_adjust_add_days_payload(self):
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = {"success": True, "obj": {"adjusted": 1, "skipped": []}}
+
+        with patch.object(sanaei_modern, "_request_with_reauth", return_value=response) as request:
+            ok, err = sanaei_modern.renew_remote_user("https://panel.example", "token", "alice", 30)
+
+        self.assertTrue(ok)
+        self.assertIsNone(err)
+        request.assert_called_once()
+        args = request.call_args.args
+        self.assertEqual(args[:7], ("POST", "https://panel.example", "token", "panel", "api", "clients", "bulkAdjust"))
+        self.assertEqual(request.call_args.kwargs["json"], {"emails": ["alice"], "addDays": 30})
+        self.assertEqual(request.call_args.kwargs["headers"], {"Content-Type": "application/json"})
+
     def test_update_payload_sends_fetched_uuid_as_id_field(self):
         response = Mock()
         response.status_code = 200


### PR DESCRIPTION
### Motivation
- The modern Sanaei API documents a `POST /panel/api/clients/bulkAdjust` endpoint for shifting expiries by days, which should be used for add-days renewals instead of the client-update path to avoid interfering with data-limit updates.

### Description
- Add `renew_remote_user(panel_url, token, username, add_days)` in `apis/sanaei_modern.py` that calls `POST panel/api/clients/bulkAdjust` with `{"emails": [username], "addDays": add_days}` and appropriate JSON headers. 
- Update the shared renewal flow in `bot.py` to prefer a panel-specific `renew_remote_user` helper when present and callable, falling back to the existing `update_remote_user(..., expire=...)` behaviour for other adapters. 
- Add a unit test `test_renew_remote_user_uses_bulk_adjust_add_days_payload` in `tests/test_sanaei_modern.py` that asserts the modern helper calls the `bulkAdjust` endpoint with the expected payload and headers. 

### Testing
- Ran the Sanaei modern unit tests with `python -m unittest tests/test_sanaei_modern.py`, which executed the test suite and passed (10 tests, all OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47886366988329850ec87ccdd1325f)