### PR TITLE
Use bulkAdjust (addBytes) for Sanaei quota edits with update fallback

### DIFF
--- a/apis/sanaei_modern.py
+++ b/apis/sanaei_modern.py
@@ -683,6 +683,80 @@ def renew_remote_user(
         return False, str(e)[:200]
 
 
+def _bulk_adjust_remote_user_quota(
+    panel_url: str,
+    token: str,
+    username: str,
+    add_bytes: int,
+) -> Tuple[bool, Optional[str]]:
+    """Shift a modern Sanaei client's quota through the documented bulkAdjust API."""
+
+    if add_bytes == 0:
+        return True, None
+    try:
+        r = _request_with_reauth(
+            "POST",
+            panel_url,
+            token,
+            "panel",
+            "api",
+            "clients",
+            "bulkAdjust",
+            json={"emails": [username], "addBytes": int(add_bytes)},
+            headers={"Content-Type": "application/json"},
+            timeout=20,
+        )
+        if r.status_code != 200:
+            return False, _response_error(r, 200)
+        data = _json_or_empty(r)
+        if not _panel_success(data):
+            return False, str(data.get("msg") or "request failed")[:200]
+        obj = _unwrap_panel_response(data)
+        if isinstance(obj, Mapping):
+            skipped = obj.get("skipped")
+            if isinstance(skipped, Iterable) and not isinstance(skipped, (str, bytes, bytearray)):
+                for item in skipped:
+                    if not isinstance(item, Mapping):
+                        continue
+                    skipped_email = _normalise_client_email(item.get("email"))
+                    if skipped_email == _normalise_client_email(username):
+                        return False, str(item.get("reason") or "quota adjustment skipped")[:200]
+        _links_cache.pop((panel_url, token, username), None)
+        return True, None
+    except Exception as e:  # pragma: no cover - network errors
+        return False, str(e)[:200]
+
+
+def _set_remote_user_quota(
+    panel_url: str,
+    token: str,
+    username: str,
+    data_limit: int,
+) -> Tuple[bool, Optional[str]]:
+    """Set an absolute quota, preferring bulkAdjust for finite-to-finite edits."""
+
+    target_limit = int(data_limit)
+    current, err = _fetch_client(panel_url, token, username)
+    if err:
+        return False, err
+    current_client = _extract_client(current)
+    current_limit = _coerce_int(_first_present(current_client, "totalGB", "total", "data_limit", "dataLimit"))
+    if current_limit is None:
+        return _update_client(panel_url, token, username, {"totalGB": target_limit})
+    if current_limit == target_limit:
+        return True, None
+    # docs/sanaei-new-version.json documents /clients/bulkAdjust as the quota
+    # shift endpoint, but it intentionally skips unlimited quotas.  Use the
+    # replacement-style update endpoint only for transitions to/from unlimited
+    # traffic or when the current quota is unavailable.
+    if current_limit == 0 or target_limit == 0:
+        return _update_client(panel_url, token, username, {"totalGB": target_limit})
+    ok, _ = _bulk_adjust_remote_user_quota(panel_url, token, username, target_limit - current_limit)
+    if ok:
+        return True, None
+    return _update_client(panel_url, token, username, {"totalGB": target_limit})
+
+
 def update_remote_user(
     panel_url: str,
     token: str,
@@ -690,11 +764,13 @@ def update_remote_user(
     data_limit: Optional[int] = None,
     expire: Optional[int] = None,
 ) -> Tuple[bool, Optional[str]]:
-    """Update quota or expiry for *username* on the modern client endpoint."""
+    """Update quota or expiry for *username* on the modern client endpoints."""
 
-    changes: Dict[str, Any] = {}
     if data_limit is not None:
-        changes["totalGB"] = int(data_limit)
+        ok, err = _set_remote_user_quota(panel_url, token, username, int(data_limit))
+        if not ok:
+            return False, err
+    changes: Dict[str, Any] = {}
     if expire is not None:
         changes["expiryTime"] = int(expire) * 1000
     if not changes:

--- a/tests/test_sanaei_modern.py
+++ b/tests/test_sanaei_modern.py
@@ -90,7 +90,40 @@ class SanaeiModernResponseTests(unittest.TestCase):
         self.assertFalse(user["enabled"])
         self.assertFalse(user["enable"])
 
-    def test_update_remote_user_uses_modern_update_endpoint_and_client_payload(self):
+    def test_update_remote_user_uses_bulk_adjust_for_finite_quota_edits(self):
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = {"success": True, "obj": {"adjusted": 1, "skipped": []}}
+        current = {
+            "email": "alice@example.com",
+            "id": 12,
+            "uuid": "uuid-1",
+            "totalGB": 1024,
+            "expiryTime": 0,
+            "enable": True,
+            "inboundIds": [7],
+            "used_traffic": 100,
+            "up": 40,
+            "down": 60,
+            "links": ["vless://example"],
+        }
+
+        with patch.object(sanaei_modern, "_fetch_client", return_value=(current, None)), patch.object(
+            sanaei_modern, "_request_with_reauth", return_value=response
+        ) as request:
+            ok, err = sanaei_modern.update_remote_user(
+                "https://panel.example", "token", "alice@example.com", data_limit=2048
+            )
+
+        self.assertTrue(ok)
+        self.assertIsNone(err)
+        request.assert_called_once()
+        args = request.call_args.args
+        self.assertEqual(args[:7], ("POST", "https://panel.example", "token", "panel", "api", "clients", "bulkAdjust"))
+        self.assertEqual(request.call_args.kwargs["json"], {"emails": ["alice@example.com"], "addBytes": 1024})
+        self.assertEqual(request.call_args.kwargs["headers"], {"Content-Type": "application/json"})
+
+    def test_update_remote_user_uses_modern_update_endpoint_for_unlimited_quota_edits(self):
         response = Mock()
         response.status_code = 200
         response.json.return_value = {"success": True, "msg": "Client updated"}
@@ -98,7 +131,7 @@ class SanaeiModernResponseTests(unittest.TestCase):
             "email": "alice@example.com",
             "id": 12,
             "uuid": "uuid-1",
-            "totalGB": 1024,
+            "totalGB": 0,
             "expiryTime": 0,
             "enable": True,
             "inboundIds": [7],
@@ -165,7 +198,7 @@ class SanaeiModernResponseTests(unittest.TestCase):
         with patch.object(sanaei_modern, "_fetch_client", return_value=(current, None)), patch.object(
             sanaei_modern, "_request_with_reauth", return_value=response
         ) as request:
-            ok, err = sanaei_modern.update_remote_user("https://panel.example", "token", "alice", data_limit=2048)
+            ok, err = sanaei_modern.update_remote_user("https://panel.example", "token", "alice", expire=1234567890)
 
         self.assertTrue(ok)
         self.assertIsNone(err)
@@ -185,7 +218,7 @@ class SanaeiModernResponseTests(unittest.TestCase):
         with patch.object(sanaei_modern, "_fetch_client", return_value=(current, None)), patch.object(
             sanaei_modern, "_request_with_reauth"
         ) as request:
-            ok, err = sanaei_modern.update_remote_user("https://panel.example", "token", "alice", data_limit=2048)
+            ok, err = sanaei_modern.update_remote_user("https://panel.example", "token", "alice", expire=1234567890)
 
         self.assertFalse(ok)
         self.assertEqual(err, "client uuid not found")


### PR DESCRIPTION
### Motivation
- The modern 3x-ui (Sanaei) API documents a `bulkAdjust` endpoint for shifting client quotas; finite-to-finite quota edits should prefer that path while transitions to/from unlimited or skipped/failed adjustments must fall back to the full client update flow.

### Description
- Added `_bulk_adjust_remote_user_quota` which calls `POST /panel/api/clients/bulkAdjust` with `addBytes` and inspects `skipped` entries for per-email failure reasons.
- Added `_set_remote_user_quota` which fetches the current client quota and prefers `bulkAdjust` for finite-to-finite edits but uses the modern `clients/update` replacement endpoint for unlimited transitions or when the current quota is unavailable or bulk adjust fails.
- Updated `update_remote_user` to use `_set_remote_user_quota` for `data_limit` edits while preserving expiry updates via the existing update path.
- Updated `tests/test_sanaei_modern.py` to assert bulkAdjust usage for finite edits, update endpoint fallback for unlimited edits, and to keep existing UUID behaviour in update payloads.

### Testing
- Ran `python3 -m unittest tests.test_sanaei_modern` and the test suite passed.
- Ran `python3 -m compileall apis/sanaei_modern.py` and module compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a478b45e20c83299dc5454d7f0919bc)