### PR TITLE
Fix modern Sanaei unlimited quota edits

### DIFF
--- a/apis/sanaei_modern.py
+++ b/apis/sanaei_modern.py
@@ -543,6 +543,17 @@ def _prepare_update_payload(current: Any, username: str, changes: Mapping[str, A
     if not client:
         return {}
     client_uuid = client.get("uuid")
+    # Older/newer modern Sanaei responses are not consistent: some return the
+    # protocol UUID in ``uuid`` while the documented client payload uses ``id``.
+    # Numeric ``id`` values can be database rows and must not be sent as the
+    # protocol id, but a non-numeric string id is the UUID/password value needed
+    # by the replacement-style update endpoint.
+    if client_uuid is None or str(client_uuid).strip() == "":
+        raw_id = client.get("id")
+        if raw_id is not None and not isinstance(raw_id, int):
+            raw_id_text = str(raw_id).strip()
+            if raw_id_text and not raw_id_text.isdigit():
+                client_uuid = raw_id_text
     if client_uuid is None or str(client_uuid).strip() == "":
         return {}
     body = {key: value for key, value in client.items() if key not in _MODERN_CLIENT_UPDATE_DROP_FIELDS}

--- a/tests/test_sanaei_modern.py
+++ b/tests/test_sanaei_modern.py
@@ -206,6 +206,37 @@ class SanaeiModernResponseTests(unittest.TestCase):
         self.assertEqual(sent_json["id"], "550e8400-e29b-41d4-a716-446655440000")
         self.assertNotIn("uuid", sent_json)
 
+
+    def test_update_remote_user_can_set_finite_quota_to_unlimited(self):
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = {"success": True, "msg": "Client updated"}
+        current = {
+            "email": "alice@example.com",
+            "id": "550e8400-e29b-41d4-a716-446655440000",
+            "totalGB": 2048,
+            "expiryTime": 0,
+            "enable": True,
+            "inboundIds": [7],
+        }
+
+        with patch.object(sanaei_modern, "_fetch_client", return_value=(current, None)), patch.object(
+            sanaei_modern, "_request_with_reauth", return_value=response
+        ) as request:
+            ok, err = sanaei_modern.update_remote_user(
+                "https://panel.example", "token", "alice@example.com", data_limit=0
+            )
+
+        self.assertTrue(ok)
+        self.assertIsNone(err)
+        request.assert_called_once()
+        args = request.call_args.args
+        self.assertEqual(args[:7], ("POST", "https://panel.example", "token", "panel", "api", "clients", "update"))
+        sent_json = request.call_args.kwargs["json"]
+        self.assertEqual(sent_json["totalGB"], 0)
+        self.assertEqual(sent_json["id"], "550e8400-e29b-41d4-a716-446655440000")
+        self.assertNotIn("inboundIds", sent_json)
+
     def test_update_refuses_to_post_without_fetched_uuid(self):
         current = {
             "email": "alice",


### PR DESCRIPTION
### Motivation
- Modern Sanaei client fetches sometimes omit `uuid` and expose the protocol identifier as a non-numeric `id` string, and the update path must include the protocol UUID to allow replacement-style updates such as setting `totalGB: 0` (unlimited).

### Description
- When preparing the modern Sanaei update payload, fall back to `client["id"]` if `uuid` is missing and `id` is a non-numeric string, while still rejecting numeric row IDs; this preserves the protocol id for `POST /panel/api/clients/update/{email}` calls.
- Add a regression test that verifies a finite quota can be changed to unlimited (`totalGB: 0`) and that the outgoing update JSON includes the protocol `id` and omits `inboundIds`.

### Testing
- Ran `python -m unittest tests.test_sanaei_modern` and the tests passed successfully.
- Ran `python -m unittest discover` in this environment which failed due to missing optional/runtime dependencies (`fastapi`, `requests`, `dotenv`) and not because of the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a478f97301883298cdafd18c3ab7fd7)