### PR TITLE
sanaei_modern: extract nested subId for sub_links and add Sanaei sub method UI/validation

### DIFF
--- a/apis/sanaei_modern.py
+++ b/apis/sanaei_modern.py
@@ -173,6 +173,28 @@ def _extract_inbound_ids(obj: Any) -> List[int]:
     return [coerced] if coerced is not None else []
 
 
+def _extract_sub_id(obj: Any) -> Optional[str]:
+    """Return a client's subscription id from modern 3x-ui response shapes."""
+
+    if not isinstance(obj, Mapping):
+        return None
+    client = _extract_client(obj)
+    value = _first_present(client, "subId", "sub_id", "subscriptionId", "subscription_id")
+    if value is None:
+        value = _first_present(obj, "subId", "sub_id", "subscriptionId", "subscription_id")
+    if value is None:
+        for key in ("obj", "data", "result"):
+            nested = obj.get(key)
+            if isinstance(nested, Mapping):
+                value = _extract_sub_id(nested)
+                if value is not None:
+                    break
+    if value is None:
+        return None
+    sub_id = str(value).strip()
+    return sub_id or None
+
+
 def _normalise_links(value: Any) -> List[str]:
     if value is None:
         return []
@@ -470,15 +492,14 @@ def fetch_links_from_panel(
 ) -> Tuple[List[str], Optional[str]]:
     """Return generated client links from modern panel."""
 
-    if sanaei_sub_method == "sub_links":
+    if (sanaei_sub_method or "links") == "sub_links":
         try:
             client_data, err = _fetch_client(panel_url, token, username)
             if err:
                 return [], err
             if not client_data:
                 return [], "client not found"
-            client_dict = _extract_client(client_data)
-            sub_id = client_dict.get("subId") or (client_data.get("subId") if isinstance(client_data, dict) else None)
+            sub_id = _extract_sub_id(client_data)
             if not sub_id:
                 return [], f"subId not found for {username}"
             r = _request_with_reauth("GET", panel_url, token, "panel", "api", "clients", "subLinks", sub_id, timeout=20)

--- a/bot.py
+++ b/bot.py
@@ -103,6 +103,10 @@ SANAEI_AUTH_TYPE_LABELS = {
     "cookie": "Cookie",
     "bearer": "Bearer / API token",
 }
+SANAEI_SUB_METHOD_LABELS = {
+    "links": "links (/panel/api/clients/links/{email})",
+    "sub_links": "subLinks (/panel/api/clients/subLinks/{subId})",
+}
 API_MODULES = {
     "marzneshin": marzneshin,
     "marzban": marzban,
@@ -1486,6 +1490,8 @@ def set_panel_append_ratio_to_name(owner_id: int, panel_id: int, enabled: bool):
         )
 
 def set_panel_sanaei_sub_method(owner_id: int, panel_id: int, method: str):
+    if method not in SANAEI_SUB_METHOD_LABELS:
+        raise ValueError(f"invalid Sanaei subscription method: {method}")
     ids = expand_owner_ids(owner_id)
     placeholders = ",".join(["%s"] * len(ids))
     params = [method, int(panel_id)] + ids
@@ -2407,6 +2413,9 @@ async def on_button(update: Update, context: ContextTypes.DEFAULT_TYPE):
         if not info:
             await q.edit_message_text("پنل پیدا نشد.")
             return ConversationHandler.END
+        if not is_modern_sanaei_panel(info):
+            await q.edit_message_text("این گزینه فقط برای نسخه modern سناعی فعال است.")
+            return ConversationHandler.END
         current_method = info.get("sanaei_sub_method") or "links"
         new_method = "sub_links" if current_method == "links" else "links"
         set_panel_sanaei_sub_method(uid, pid, new_method)
@@ -3064,7 +3073,7 @@ async def show_panel_card(q, context: ContextTypes.DEFAULT_TYPE, owner_id: int, 
         lines.append(f"🔗 Sub URL: <code>{p.get('sub_url') or '-'}</code>")
     if is_modern_sanaei:
         sub_method = p.get("sanaei_sub_method") or "links"
-        sub_method_label = "subLinks" if sub_method == "sub_links" else "links"
+        sub_method_label = SANAEI_SUB_METHOD_LABELS.get(sub_method, SANAEI_SUB_METHOD_LABELS["links"])
         lines.append(f"🔄 Sub Method: <b>{sub_method_label}</b>")
     lines += [
         "",
@@ -3088,7 +3097,8 @@ async def show_panel_card(q, context: ContextTypes.DEFAULT_TYPE, owner_id: int, 
         kb.append([InlineKeyboardButton("🔢 فیلتر بر اساس شماره", callback_data="p_filter_cfgnums")])
     if is_modern_sanaei:
         sub_method = p.get("sanaei_sub_method") or "links"
-        sub_method_btn = "🔄 Sub Method: " + ("links" if sub_method == "sub_links" else "subLinks")
+        next_method = "links" if sub_method == "sub_links" else "sub_links"
+        sub_method_btn = "🔄 Switch Sub Method to " + SANAEI_SUB_METHOD_LABELS[next_method]
         kb.append([InlineKeyboardButton(sub_method_btn, callback_data="p_toggle_sub_method")])
     kb.append([InlineKeyboardButton("🗑️ Remove Panel", callback_data="p_remove")])
     kb.append([InlineKeyboardButton("⬅️ Back", callback_data="manage_panels")])

--- a/tests/test_sanaei_modern.py
+++ b/tests/test_sanaei_modern.py
@@ -368,6 +368,35 @@ class SanaeiModernResponseTests(unittest.TestCase):
         self.assertEqual(args[:7], ("GET", "https://panel.example", "token", "panel", "api", "clients", "subLinks"))
         self.assertEqual(args[7], "sub-id-12345")
 
+    def test_fetch_links_from_panel_sub_links_accepts_nested_subscription_id(self):
+        client_response = {
+            "client": {
+                "email": "alice@example.com",
+                "sub_id": "nested-sub-id",
+                "uuid": "uuid-1",
+            },
+            "inboundIds": [7],
+        }
+        sublinks_response = Mock()
+        sublinks_response.status_code = 200
+        sublinks_response.json.return_value = {
+            "success": True,
+            "obj": ["vless://uuid-1@host:443?security=none#alice"],
+        }
+
+        with patch.object(sanaei_modern, "_fetch_client", return_value=(client_response, None)), patch.object(
+            sanaei_modern, "_request_with_reauth", return_value=sublinks_response
+        ) as request:
+            links, err = sanaei_modern.fetch_links_from_panel(
+                "https://panel.example", "token", "alice@example.com", sanaei_sub_method="sub_links"
+            )
+
+        self.assertEqual(links, ["vless://uuid-1@host:443?security=none#alice"])
+        self.assertIsNone(err)
+        args = request.call_args.args
+        self.assertEqual(args[:7], ("GET", "https://panel.example", "token", "panel", "api", "clients", "subLinks"))
+        self.assertEqual(args[7], "nested-sub-id")
+
     def test_fetch_links_from_panel_sub_links_handles_missing_subid(self):
         client_response = {
             "email": "alice@example.com",


### PR DESCRIPTION
### Motivation

- Ensure `fetch_links_from_panel(..., sanaei_sub_method="sub_links")` can locate subscription IDs that appear in nested shapes returned by modern Sanaei (3x-ui) responses.
- Expose and validate the Sanaei subscription link fetching method in the bot UI so admins can switch between `links` and `sub_links` safely and with clear labels.

### Description

- Added `_extract_sub_id(obj: Any) -> Optional[str]` to robustly find a subscription id from client/response objects by checking common keys and nested containers and returning a normalized string or `None`.
- Made `fetch_links_from_panel` use `_extract_sub_id` to derive the `subId` when `sanaei_sub_method` is `sub_links`, and made the `sanaei_sub_method` comparison defensive by treating `None` as `"links"` (`if (sanaei_sub_method or "links") == "sub_links"`).
- Added `SANAEI_SUB_METHOD_LABELS` mapping and used it to display human-friendly sub method labels in the panel card and toggle button, and updated the toggle button text to indicate the next method.
- Added validation in `set_panel_sanaei_sub_method` to reject invalid method values by raising `ValueError`.
- Prevent toggling the Sanaei sub method for legacy panels by checking `is_modern_sanaei_panel(info)` and showing a message for non-modern panels.
- Added a unit test `test_fetch_links_from_panel_sub_links_accepts_nested_subscription_id` to ensure nested subscription ids are accepted when calling `fetch_links_from_panel(..., sanaei_sub_method="sub_links")`.

### Testing

- Ran the unit tests in `tests/test_sanaei_modern.py`, including the new `test_fetch_links_from_panel_sub_links_accepts_nested_subscription_id`, and all tests in that file passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54d6e419108330bd648a538dcf78a9)