### PR TITLE
Fix add-panel type selection callbacks

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1833,6 +1833,39 @@ async def on_button(update: Update, context: ContextTypes.DEFAULT_TYPE):
     data = q.data
     uid = update.effective_user.id
 
+    # Keep add-panel inline selections responsive even if Telegram delivers the
+    # callback outside the expected conversation state (for example after a bot
+    # restart or after another callback handler has ended the conversation).
+    if data.startswith("add_panel_type:"):
+        if not is_admin(uid):
+            await q.edit_message_text("دسترسی ندارید.")
+            return ConversationHandler.END
+        panel_type = data.split(":", 1)[1].strip().lower()
+        if panel_type not in PANEL_TYPES:
+            await q.edit_message_text("❌ نوع پنل نامعتبر. دوباره انتخاب کن:", reply_markup=_panel_type_kb())
+            return ASK_PANEL_TYPE
+        return await _apply_panel_type(panel_type, context, q.edit_message_text)
+
+    if data.startswith("add_sanaei_version:"):
+        if not is_admin(uid):
+            await q.edit_message_text("دسترسی ندارید.")
+            return ConversationHandler.END
+        version = data.split(":", 1)[1].strip().lower()
+        if version not in SANAEI_VERSION_LABELS:
+            await q.edit_message_text("❌ نسخه نامعتبر. دوباره انتخاب کن:", reply_markup=_sanaei_version_kb())
+            return ASK_SANAEI_VERSION
+        return await _apply_sanaei_version(version, context, q.edit_message_text)
+
+    if data.startswith("add_sanaei_auth:"):
+        if not is_admin(uid):
+            await q.edit_message_text("دسترسی ندارید.")
+            return ConversationHandler.END
+        auth_type = data.split(":", 1)[1].strip().lower()
+        if auth_type not in SANAEI_AUTH_TYPE_LABELS:
+            await q.edit_message_text("❌ نوع احراز هویت نامعتبر. دوباره انتخاب کن:", reply_markup=_sanaei_auth_type_kb())
+            return ASK_SANAEI_AUTH_TYPE
+        return await _apply_sanaei_auth_type(auth_type, context, q.edit_message_text)
+
     if data == "admin_panel":
         if not is_admin(uid):
             await q.edit_message_text("دسترسی ندارید.")


### PR DESCRIPTION
### Motivation

- Inline buttons for selecting a panel type / Sanaei version / Sanaei auth were not handled when Telegram delivered the callback outside the expected conversation state, making clicks appear to do nothing.
- Provide a resilient fallback so those inline selections remain responsive even after a bot restart or when the conversation state isn't active.

### Description

- Added fallback handling in the main callback router (`on_button`) for callback data starting with `add_panel_type:`, `add_sanaei_version:`, and `add_sanaei_auth:` so they are processed even if the conversation state is not active.
- Each new branch preserves the existing admin permission checks and validation against `PANEL_TYPES`, `SANAEI_VERSION_LABELS`, and `SANAEI_AUTH_TYPE_LABELS` and returns the appropriate conversation state on invalid input.
- When valid, the handlers delegate to the existing helper functions (`_apply_panel_type`, `_apply_sanaei_version`, `_apply_sanaei_auth_type`) and reply via the callback query message editor to continue the add-panel flow.
- The change is implemented in `bot.py` with a short explanatory comment above the new fallback branches.

### Testing

- Ran `python -m py_compile bot.py` to verify the module compiles successfully (no syntax errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54da1c4964833089154bffbbe83940)