### PR TITLE
Add automatic MySQL backups with Telegram delivery and admin UI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.11-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    bash netcat-openbsd gcc default-libmysqlclient-dev \
+    bash netcat-openbsd gcc default-libmysqlclient-dev default-mysql-client \
  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/bot.py
+++ b/bot.py
@@ -77,6 +77,14 @@ from services import (
     ensure_panel_tokens,
 )
 from models.admins import TokenEncryptionError as AdminTokenEncryptionError
+from services.backups import (
+    create_and_send_backup,
+    get_backup_settings,
+    is_main_admin,
+    set_backup_enabled,
+    set_backup_interval_hours,
+    backup_scheduler_loop,
+)
 
 # ---------- logging ----------
 logging.basicConfig(
@@ -351,7 +359,8 @@ def get_manage_owner_id(context: ContextTypes.DEFAULT_TYPE, actor_id: int) -> in
     ASK_NORMAL_SYNC_INTERVAL,
     ASK_WEBUI_USERNAME,
     ASK_WEBUI_PASSWORD,
-) = range(47)
+    ASK_BACKUP_INTERVAL,
+) = range(48)
 
 # ---------- helpers ----------
 UNIT = 1024
@@ -598,7 +607,10 @@ def _admin_technical_kb(owner_id: int) -> InlineKeyboardMarkup:
         or ""
     ).strip()
     webui_config_label = f"🔐 Web UI Login: {webui_username}" if webui_username else "🔐 Web UI Login: not set"
-    kb = [
+    backup_rows = []
+    if is_main_admin(owner_id):
+        backup_rows.append([InlineKeyboardButton("🗄️ Automatic Backups", callback_data="automatic_backups")])
+    kb = backup_rows + [
         [InlineKeyboardButton(notif_label, callback_data="toggle_limit_event_notifications")],
         [InlineKeyboardButton(_sub_placeholder_toggle_label(owner_id), callback_data="toggle_sub_placeholder")],
         _sub_placeholder_template_button(owner_id),
@@ -1927,6 +1939,46 @@ async def on_button(update: Update, context: ContextTypes.DEFAULT_TYPE):
             await q.edit_message_text("دسترسی ندارید.")
             return ConversationHandler.END
         await q.edit_message_text("Settings:", reply_markup=_agent_technical_kb(uid))
+        return ConversationHandler.END
+
+    if data == "automatic_backups":
+        if not is_main_admin(uid):
+            await q.edit_message_text("دسترسی ندارید.")
+            return ConversationHandler.END
+        await q.edit_message_text(_backup_settings_text(), reply_markup=_backup_settings_kb(), parse_mode="HTML")
+        return ConversationHandler.END
+
+    if data == "backup_toggle":
+        if not is_main_admin(uid):
+            await q.edit_message_text("دسترسی ندارید.")
+            return ConversationHandler.END
+        current = get_backup_settings().enabled
+        set_backup_enabled(not current)
+        await q.edit_message_text(_backup_settings_text(), reply_markup=_backup_settings_kb(), parse_mode="HTML")
+        return ConversationHandler.END
+
+    if data == "backup_interval":
+        if not is_main_admin(uid):
+            await q.edit_message_text("دسترسی ندارید.")
+            return ConversationHandler.END
+        cur = get_backup_settings().interval_hours
+        await q.edit_message_text(
+            f"بازه فعلی بکاپ: {cur} ساعت\n\nعدد جدید را بفرست (حداقل 1 ساعت):",
+            reply_markup=_back_kb("automatic_backups"),
+        )
+        return ASK_BACKUP_INTERVAL
+
+    if data == "backup_now":
+        if not is_main_admin(uid):
+            await q.edit_message_text("دسترسی ندارید.")
+            return ConversationHandler.END
+        await q.edit_message_text("⏳ Backup started. The bot will send the archive when it is ready.", reply_markup=_back_kb("automatic_backups"))
+        async def _run_manual_backup():
+            try:
+                await create_and_send_backup(context.bot, uid)
+            except Exception:
+                pass
+        context.application.create_task(_run_manual_backup())
         return ConversationHandler.END
 
     if data == "toggle_limit_event_notifications":
@@ -3479,6 +3531,46 @@ async def got_preset_days(update: Update, context: ContextTypes.DEFAULT_TYPE):
             await update.message.reply_text(*a, **k)
     return await show_preset_menu(Fake(), context, update.effective_user.id, notice=notice)
 
+
+def _backup_settings_text() -> str:
+    settings = get_backup_settings()
+    last = settings.last_run_at.strftime("%Y-%m-%d %H:%M:%S UTC") if settings.last_run_at else "—"
+    return (
+        "🗄️ <b>Automatic Backups</b>\n\n"
+        f"Status: <b>{'ON' if settings.enabled else 'OFF'}</b>\n"
+        f"Backup Interval: <b>{settings.interval_hours} hour(s)</b>\n"
+        f"Backup Directory: <code>{settings.backup_dir}</code>\n"
+        f"Last Backup: <b>{last}</b>\n\n"
+        "Backups include <code>database.sql</code> and <code>.env</code>, are saved on the server, "
+        "and are sent to the main admin as Telegram documents."
+    )
+
+
+def _backup_settings_kb() -> InlineKeyboardMarkup:
+    settings = get_backup_settings()
+    toggle_label = "🟢 Automatic Backups: ON" if settings.enabled else "🔴 Automatic Backups: OFF"
+    return InlineKeyboardMarkup([
+        [InlineKeyboardButton(toggle_label, callback_data="backup_toggle")],
+        [InlineKeyboardButton(f"⏱️ Interval: {settings.interval_hours}h", callback_data="backup_interval")],
+        [InlineKeyboardButton("▶️ Backup Now", callback_data="backup_now")],
+        [InlineKeyboardButton("⬅️ Back", callback_data="admin_technical")],
+    ])
+
+
+async def got_backup_interval(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    uid = update.effective_user.id
+    if not is_main_admin(uid):
+        return ConversationHandler.END
+    try:
+        hours = int(float((update.message.text or "").strip()))
+        assert hours >= 1
+    except Exception:
+        await update.message.reply_text("❌ عدد معتبر حداقل 1 ساعت بفرست:")
+        return ASK_BACKUP_INTERVAL
+    set_backup_interval_hours(hours)
+    await update.message.reply_text("✅ بازه بکاپ ذخیره شد.", reply_markup=_back_kb("automatic_backups"))
+    return ConversationHandler.END
+
 # ---------- settings (admin) ----------
 async def got_limit_msg(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if not is_admin(update.effective_user.id):
@@ -4997,6 +5089,10 @@ async def sync_user_panels_async(
     )
 
 # ---------- wiring ----------
+async def _post_init(application: Application) -> None:
+    application.create_task(backup_scheduler_loop(application.bot))
+
+
 def build_app():
     load_dotenv()
     tok = os.getenv("BOT_TOKEN", "").strip()
@@ -5004,7 +5100,7 @@ def build_app():
         raise RuntimeError("BOT_TOKEN missing in .env")
     init_mysql_pool()
     ensure_schema()
-    app = Application.builder().token(tok).build()
+    app = Application.builder().token(tok).post_init(_post_init).build()
 
     conv = ConversationHandler(
         entry_points=[CommandHandler("start", start), CallbackQueryHandler(on_button)],
@@ -5065,6 +5161,7 @@ def build_app():
             ASK_NORMAL_SYNC_INTERVAL: [MessageHandler(filters.TEXT & ~filters.COMMAND, got_normal_sync_interval)],
             ASK_WEBUI_USERNAME: [MessageHandler(filters.TEXT & ~filters.COMMAND, got_webui_username)],
             ASK_WEBUI_PASSWORD: [MessageHandler(filters.TEXT & ~filters.COMMAND, got_webui_password)],
+            ASK_BACKUP_INTERVAL: [MessageHandler(filters.TEXT & ~filters.COMMAND, got_backup_interval)],
 
             # preset mgmt
             ASK_PRESET_GB:   [MessageHandler(filters.TEXT & ~filters.COMMAND, got_preset_gb)],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,9 +65,12 @@ services:
       MYSQL_DATABASE: ${MYSQL_DATABASE}
       PUBLIC_BASE_URL: ${PUBLIC_BASE_URL}
       USAGE_SYNC_INTERVAL: ${USAGE_SYNC_INTERVAL}
+      BACKUP_DIR: ${BACKUP_DIR:-/app/backups}
       AGENT_TOKEN_ENCRYPTION_KEY: ${AGENT_TOKEN_ENCRYPTION_KEY:-}
       AGENT_TOKEN_ENCRYPTION_OLD_KEYS: ${AGENT_TOKEN_ENCRYPTION_OLD_KEYS:-}
       SERVICE: bot
+    volumes:
+      - ./backups:/app/backups
 
 
   certbot-renew:

--- a/services/backups.py
+++ b/services/backups.py
@@ -1,0 +1,266 @@
+"""Automatic MySQL backup creation and Telegram delivery helpers."""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shutil
+import socket
+import subprocess
+import tarfile
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from dotenv import load_dotenv
+from telegram import Bot
+
+from api.subscription_aggregator import ordered_admin_ids
+from services.settings import get_setting_exact, set_setting
+
+log = logging.getLogger(__name__)
+
+BACKUP_ENABLED_KEY = "automatic_backups_enabled"
+BACKUP_INTERVAL_KEY = "automatic_backups_interval_hours"
+BACKUP_LAST_RUN_KEY = "automatic_backups_last_run_at"
+DEFAULT_BACKUP_INTERVAL_HOURS = 24
+DEFAULT_BACKUP_DIR = "/app/backups"
+MAX_BACKUP_FILES = 30
+
+
+@dataclass(frozen=True)
+class BackupSettings:
+    enabled: bool
+    interval_hours: int
+    backup_dir: Path
+    last_run_at: datetime | None
+
+
+@dataclass(frozen=True)
+class BackupResult:
+    archive_path: Path
+    created_at: datetime
+    size_bytes: int
+    database: str
+    hostname: str
+
+
+def main_admin_id() -> int | None:
+    admins = ordered_admin_ids()
+    return int(admins[0]) if admins else None
+
+
+def is_main_admin(tg_id: int | None) -> bool:
+    root = main_admin_id()
+    return root is not None and tg_id is not None and int(tg_id) == root
+
+
+def _setting_owner() -> int | None:
+    return main_admin_id()
+
+
+def _parse_dt(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _env_int(key: str, default: int) -> int:
+    raw = os.getenv(key)
+    try:
+        return int(raw) if raw is not None else default
+    except ValueError:
+        log.warning("Invalid %s=%r; using %s", key, raw, default)
+        return default
+
+
+def backup_directory() -> Path:
+    return Path(os.getenv("BACKUP_DIR", DEFAULT_BACKUP_DIR)).expanduser()
+
+
+def get_backup_settings() -> BackupSettings:
+    owner = _setting_owner()
+    enabled_raw = get_setting_exact(owner, BACKUP_ENABLED_KEY) if owner is not None else None
+    interval_raw = get_setting_exact(owner, BACKUP_INTERVAL_KEY) if owner is not None else None
+    last_raw = get_setting_exact(owner, BACKUP_LAST_RUN_KEY) if owner is not None else None
+    try:
+        interval = int(float(interval_raw or DEFAULT_BACKUP_INTERVAL_HOURS))
+    except ValueError:
+        interval = DEFAULT_BACKUP_INTERVAL_HOURS
+    return BackupSettings(
+        enabled=(enabled_raw or "0") != "0",
+        interval_hours=max(1, interval),
+        backup_dir=backup_directory(),
+        last_run_at=_parse_dt(last_raw),
+    )
+
+
+def set_backup_enabled(enabled: bool) -> None:
+    owner = _setting_owner()
+    if owner is None:
+        raise RuntimeError("No main admin is configured")
+    set_setting(owner, BACKUP_ENABLED_KEY, "1" if enabled else "0")
+
+
+def set_backup_interval_hours(hours: int) -> None:
+    owner = _setting_owner()
+    if owner is None:
+        raise RuntimeError("No main admin is configured")
+    set_setting(owner, BACKUP_INTERVAL_KEY, str(max(1, int(hours))))
+
+
+def mark_backup_run(when: datetime) -> None:
+    owner = _setting_owner()
+    if owner is not None:
+        set_setting(owner, BACKUP_LAST_RUN_KEY, when.astimezone(timezone.utc).isoformat())
+
+
+def _mysql_env() -> dict[str, str]:
+    load_dotenv()
+    env = os.environ.copy()
+    password = os.getenv("MYSQL_PASSWORD", "")
+    if password:
+        env["MYSQL_PWD"] = password
+    return env
+
+
+def _dump_database(output_path: Path) -> str:
+    load_dotenv()
+    database = os.getenv("MYSQL_DATABASE", "botdb")
+    mysqldump_bin = os.getenv("MYSQLDUMP_BIN", "mysqldump")
+    if shutil.which(mysqldump_bin) is None:
+        raise RuntimeError(
+            f"{mysqldump_bin!r} was not found. Install default-mysql-client/mysql-client "
+            "or set MYSQLDUMP_BIN to the mysqldump executable path."
+        )
+    cmd = [
+        mysqldump_bin,
+        "--single-transaction",
+        "--quick",
+        "--routines",
+        "--triggers",
+        "-h", os.getenv("MYSQL_HOST", "127.0.0.1"),
+        "-P", str(_env_int("MYSQL_PORT", 3306)),
+        "-u", os.getenv("MYSQL_USER", "root"),
+        database,
+    ]
+    with output_path.open("wb") as fh:
+        subprocess.run(cmd, stdout=fh, stderr=subprocess.PIPE, env=_mysql_env(), check=True)
+    return database
+
+
+def _copy_env_file(output_path: Path) -> None:
+    env_path = Path(os.getenv("ENV_FILE_PATH", ".env"))
+    if not env_path.is_absolute():
+        env_path = Path.cwd() / env_path
+    if env_path.exists():
+        shutil.copyfile(env_path, output_path)
+    else:
+        output_path.write_text("", encoding="utf-8")
+        log.warning(".env file not found at %s; adding empty .env to backup", env_path)
+
+
+def _archive_backup(source_dir: Path, archive_path: Path) -> Path:
+    try:
+        with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            zf.write(source_dir / "database.sql", "database.sql")
+            zf.write(source_dir / ".env", ".env")
+        return archive_path
+    except Exception:
+        log.exception("zip archive creation failed; falling back to tar.gz")
+    archive_path = archive_path.with_suffix(".tar.gz")
+    with tarfile.open(archive_path, "w:gz") as tf:
+        tf.add(source_dir / "database.sql", arcname="database.sql")
+        tf.add(source_dir / ".env", arcname=".env")
+    return archive_path
+
+
+def _cleanup_old_backups(backup_dir: Path) -> None:
+    files = sorted(
+        [p for p in backup_dir.glob("backup_*") if p.is_file()],
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    for old in files[MAX_BACKUP_FILES:]:
+        try:
+            old.unlink()
+        except OSError:
+            log.warning("Failed to delete old backup %s", old, exc_info=True)
+
+
+def create_backup() -> BackupResult:
+    created_at = datetime.now(timezone.utc)
+    backup_dir = backup_directory()
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    stamp = created_at.strftime("%Y-%m-%d_%H-%M")
+    archive_path = backup_dir / f"backup_{stamp}.zip"
+    with tempfile.TemporaryDirectory(prefix="backup_", dir=str(backup_dir)) as tmp:
+        tmpdir = Path(tmp)
+        database = _dump_database(tmpdir / "database.sql")
+        _copy_env_file(tmpdir / ".env")
+        archive_path = _archive_backup(tmpdir, archive_path)
+    _cleanup_old_backups(backup_dir)
+    result = BackupResult(archive_path, created_at, archive_path.stat().st_size, database, socket.gethostname())
+    log.info("Created backup %s (%s bytes)", result.archive_path, result.size_bytes)
+    return result
+
+
+def format_size(size: int) -> str:
+    for unit in ("B", "KB", "MB", "GB"):
+        if size < 1024 or unit == "GB":
+            return f"{size:.1f} {unit}" if unit != "B" else f"{size} B"
+        size /= 1024
+    return f"{size} B"
+
+
+def backup_caption(result: BackupResult) -> str:
+    return (
+        f"🗄️ Database backup\n"
+        f"Date/time: {result.created_at.strftime('%Y-%m-%d %H:%M:%S UTC')}\n"
+        f"File size: {format_size(result.size_bytes)}\n"
+        f"Database: {result.database}\n"
+        f"Hostname: {result.hostname}"
+    )
+
+
+async def create_and_send_backup(bot: Bot, chat_id: int) -> BackupResult:
+    log.info("Starting backup attempt for chat_id=%s", chat_id)
+    try:
+        result = await asyncio.to_thread(create_backup)
+        with result.archive_path.open("rb") as fh:
+            await bot.send_document(chat_id=chat_id, document=fh, filename=result.archive_path.name, caption=backup_caption(result))
+        mark_backup_run(result.created_at)
+        log.info("Backup %s sent to chat_id=%s", result.archive_path, chat_id)
+        return result
+    except Exception as exc:
+        log.exception("Backup attempt failed")
+        try:
+            await bot.send_message(chat_id=chat_id, text=f"❌ Backup failed: {exc}")
+        except Exception:
+            log.exception("Failed to notify main admin about backup failure")
+        raise
+
+
+async def backup_scheduler_loop(bot: Bot, stop_event: asyncio.Event | None = None) -> None:
+    log.info("Automatic backup scheduler started")
+    while stop_event is None or not stop_event.is_set():
+        try:
+            admin_id = main_admin_id()
+            settings = get_backup_settings()
+            now = datetime.now(timezone.utc)
+            due = settings.last_run_at is None or (now - settings.last_run_at).total_seconds() >= settings.interval_hours * 3600
+            if admin_id is not None and settings.enabled and due:
+                await create_and_send_backup(bot, admin_id)
+        except Exception:
+            pass
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=60) if stop_event else await asyncio.sleep(60)
+        except asyncio.TimeoutError:
+            pass


### PR DESCRIPTION
### Motivation
- Provide automatic periodic backups of the MySQL database and `.env` and deliver them to the main admin via Telegram.
- Expose backup controls in the admin UI so the main admin can enable/disable, change interval, and run manual backups.
- Ensure `mysqldump` is available in the runtime image and persist backups on the host.

### Description
- Added a new module `services/backups.py` that implements backup creation (`create_backup`), zipping/archiving, retention cleanup, settings helpers (`get_backup_settings`, `set_backup_enabled`, `set_backup_interval_hours`), and an async scheduler (`backup_scheduler_loop`) and sender (`create_and_send_backup`).
- Integrated backup UI and handlers into `bot.py`: imported backup functions, added `ASK_BACKUP_INTERVAL` state, admin keyboard entry for "Automatic Backups", handlers for toggling, interval input, and manual backup triggering, and started the scheduler via `Application.post_init` (`_post_init`).
- Updated `Dockerfile` to install a MySQL client (`default-mysql-client`) so `mysqldump` is available at runtime and kept previous dependencies.
- Updated `docker-compose.yml` to add `BACKUP_DIR` environment variable and mount `./backups` into the bot container to persist created archives.

### Testing
- No automated tests were added or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a63588ead808330b04becea190e6d11)